### PR TITLE
chore: remove outdated issue templates to streamline reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,12 +6,3 @@ contact_links:
   - name: 📖 Documentation
     url: https://github.com/techsquidtv/hermes/tree/main/docs
     about: Check our documentation first - many questions are already answered
-  - name: 🐛 Bug Reports
-    url: https://github.com/techsquidtv/hermes/issues/new?template=bug_report.yml
-    about: Report bugs and unexpected behavior
-  - name: ✨ Feature Requests
-    url: https://github.com/techsquidtv/hermes/issues/new?template=feature_request.yml
-    about: Suggest new features and enhancements
-  - name: 📚 Documentation Issues
-    url: https://github.com/techsquidtv/hermes/issues/new?template=documentation.yml
-    about: Report documentation problems or suggest improvements


### PR DESCRIPTION
- Eliminated bug report, feature request, and documentation issue templates from the GitHub issue configuration to simplify the issue reporting process.

## What changed?
<!-- Brief description of what this PR does and why -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor/cleanup
- [ ] Documentation
- [ ] DevOps/Infrastructure

## Package(s) affected
- [ ] hermes-api (Backend/API)
- [ ] hermes-app (Frontend/UI)
- [ ] docs (Documentation)
- [ ] devops (Docker/Deployment)
- [ ] general (Cross-cutting)

## Testing
- [ ] Tests pass locally (`pnpm test` or `pnpm test:api`)
- [ ] Added/updated tests if needed
- [ ] Manual testing completed

## Related Issues
<!-- Link related issues. Use "Closes #123" to auto-close issues when merged -->
Closes #

## Additional context
<!-- Screenshots, performance notes, breaking changes, etc. (optional) -->
