### PR TITLE
feat: enhance environment variable handling for API keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,7 +84,10 @@ HERMES_TEMP_DIR=./packages/hermes-api/temp
 # API KEYS & AUTHENTICATION
 # =============================================================================
 
-# Comma-separated list of valid API keys (if using API key auth)
+# Valid API keys (if using API key auth) - supports multiple formats:
+# - Comma-separated: key1,key2,key3
+# - JSON array: ["key1","key2","key3"]
+# - Space-separated: key1 key2 key3
 HERMES_API_KEYS=
 
 # =============================================================================
@@ -110,7 +113,10 @@ HERMES_LOGIN_ATTEMPT_WINDOW_MINUTES=15
 # CORS CONFIGURATION
 # =============================================================================
 
-# Comma-separated list of allowed CORS origins
+# Allowed CORS origins - supports multiple formats:
+# - Comma-separated: http://localhost:3000,http://localhost:5173
+# - JSON array: ["http://localhost:3000","http://localhost:5173"]
+# - Space-separated: http://localhost:3000 http://localhost:5173
 # Include your frontend domain(s) here
 # Examples:
 # - Development: http://localhost:3000,http://localhost:5173,http://localhost:8000


### PR DESCRIPTION
This pull request enhances the configuration handling for the Hermes API by introducing robust parsing of environment variables for list fields. The main improvement is support for multiple formats (comma-separated, space-separated, and JSON arrays) for fields such as API keys and allowed CORS origins, making environment setup more flexible and less error-prone. Documentation in `.env.example` has also been updated to reflect these changes.

**Configuration parsing improvements:**

* Added `CustomEnvSettingsSource` in `config.py` to support flexible list parsing for `api_keys` and `allowed_origins` fields, allowing values to be specified as comma-separated, space-separated, or JSON array strings.
* Overrode the `settings_customise_sources` method in the `Settings` class to use the new custom environment source for robust list field parsing.

**Documentation updates:**

* Updated `.env.example` to document the new supported formats for `HERMES_API_KEYS`, including comma-separated, JSON array, and space-separated values.
* Updated `.env.example` to document the new supported formats for allowed CORS origins, including comma-separated, JSON array, and space-separated values.