### PR TITLE
chore: sqlite only supported

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,6 @@ HERMES_DEV_PORT=5173
 
 # Database connection URL
 # Development: sqlite+aiosqlite:///./data/hermes.db
-# Production: postgresql+asyncpg://user:password@db:5432/hermes
 HERMES_DATABASE_URL=sqlite+aiosqlite:///./data/hermes.db
 
 # Enable SQL query logging (development only)
@@ -170,32 +169,3 @@ VITE_API_BASE_URL=/api/v1
 
 # Note: SSE is always enabled in both frontend and backend
 # No configuration variable needed - it's a core requirement for real-time updates
-
-# =============================================================================
-# DEVELOPMENT SETUP
-# =============================================================================
-
-# For development with Docker Compose:
-# 1. Copy this file: cp .env.example .env
-# 2. Generate secret key: python3 -c "import secrets; print(secrets.token_urlsafe(32))"
-# 3. Run: docker compose -f docker-compose.dev.yml up
-
-# =============================================================================
-# PRODUCTION SETUP EXAMPLES
-# =============================================================================
-
-# Example 1: Single Domain (hermes.example.com)
-# HERMES_DEBUG=false
-# HERMES_SECRET_KEY=your-secure-production-key
-# HERMES_DATABASE_URL=postgresql+asyncpg://user:password@db:5432/hermes
-# HERMES_REDIS_URL=redis://redis:6379/0
-# HERMES_ALLOWED_ORIGINS=https://hermes.example.com
-# VITE_API_BASE_URL=/api/v1
-
-# Example 2: Separate Domains (hermes.example.com + hermes-api.example.com)
-# HERMES_DEBUG=false  
-# HERMES_SECRET_KEY=your-secure-production-key
-# HERMES_DATABASE_URL=postgresql+asyncpg://user:password@db:5432/hermes
-# HERMES_REDIS_URL=redis://redis:6379/0
-# HERMES_ALLOWED_ORIGINS=https://hermes.example.com,https://hermes-api.example.com
-# VITE_API_BASE_URL=https://hermes-api.example.com/api/v1

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -26,7 +26,7 @@ All configuration is managed through environment variables with the `HERMES_` pr
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `HERMES_DATABASE_URL` | `sqlite+aiosqlite:///./data/hermes.db` | Database connection URL. Supports SQLite, PostgreSQL, MySQL. |
+| `HERMES_DATABASE_URL` | `sqlite+aiosqlite:///./data/hermes.db` | Database connection URL. **SQLite only** - uses aiosqlite for async support. |
 | `HERMES_DATABASE_ECHO` | `false` | Enable SQL query logging for debugging |
 
 ### Redis Configuration
@@ -149,12 +149,12 @@ HERMES_REDIS_URL=redis://localhost:6379
 API_PORT=8000
 ```
 
-### Production with PostgreSQL
+### Production
 
 ```bash
 HERMES_DEBUG=false
 HERMES_SECRET_KEY=your-production-secret-key-change-this
-HERMES_DATABASE_URL=postgresql+asyncpg://user:password@db:5432/hermes
+HERMES_DATABASE_URL=sqlite+aiosqlite:///./data/hermes.db
 HERMES_REDIS_URL=redis://redis:6379/0
 API_PORT=8000
 HERMES_RATE_LIMIT_PER_MINUTE=30
@@ -166,7 +166,7 @@ HERMES_RATE_LIMIT_PER_MINUTE=30
 # In .env file
 HERMES_DEBUG=false
 HERMES_SECRET_KEY=your-secure-production-key
-HERMES_DATABASE_URL=postgresql+asyncpg://user:password@db/hermes
+HERMES_DATABASE_URL=sqlite+aiosqlite:///./data/hermes.db
 HERMES_REDIS_URL=redis://redis:6379
 API_PORT=8000
 HERMES_APP_PORT=3000
@@ -213,7 +213,7 @@ openssl rand -hex 32
 **Database connection errors:**
 - Verify `HERMES_DATABASE_URL` format is correct
 - For SQLite: `sqlite+aiosqlite:///path/to/db.sqlite`
-- For PostgreSQL: `postgresql+asyncpg://user:password@host:port/db`
+- **Note:** Only SQLite is currently supported
 
 **Redis connection errors:**
 - Verify `HERMES_REDIS_URL` is accessible

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -51,7 +51,7 @@ Temporary files are stored separately to avoid cluttering the download directory
 
 1. **Set `HERMES_DEBUG=false`** in your `.env` file
 2. **Use a secure `HERMES_SECRET_KEY`** (generate with the methods in CONFIGURATION.md)
-3. **Configure production database URL** (PostgreSQL recommended for production)
+3. **Ensure SQLite database is properly backed up**
 4. **Set up proper Redis configuration**
 5. **Configure CORS origins** for your domain(s)
 6. **Set frontend API URL** if using separate domains
@@ -97,7 +97,7 @@ docker run -d \
   -p 8000:8000 \
   -e HERMES_SECRET_KEY=your-secret \
   -e HERMES_DEBUG=false \
-  -e HERMES_DATABASE_URL=postgresql+asyncpg://user:pass@db/hermes \
+  -e HERMES_DATABASE_URL=sqlite+aiosqlite:///./data/hermes.db \
   -v /data/hermes/downloads:/app/downloads \
   -v /data/hermes/data:/app/data \
   hermes-api:latest
@@ -178,11 +178,12 @@ The version status appears in the bottom-left of the sidebar and provides:
 ### Database Backups
 
 ```bash
-# SQLite backup (development)
+# SQLite backup
 cp packages/hermes-api/data/hermes.db packages/hermes-api/data/hermes.db.backup
 
-# PostgreSQL backup (production)
-pg_dump hermes > hermes_backup.sql
+# Create timestamped backup
+cp packages/hermes-api/data/hermes.db \
+   packages/hermes-api/data/hermes.db.backup.$(date +%Y%m%d_%H%M%S)
 ```
 
 ### File Backups
@@ -384,11 +385,7 @@ HERMES_DATABASE_ECHO=true
   ```env
   HERMES_DATABASE_ECHO=true  # Enable query logging (dev only)
   ```
-
-- **Use PostgreSQL** for better performance under load:
-  ```env
-  HERMES_DATABASE_URL=postgresql+asyncpg://user:pass@db:5432/hermes
-  ```
+  **Note:** Hermes uses SQLite for simplicity. For high-traffic production deployments, consider implementing database connection pooling or migrating to PostgreSQL (requires code changes).
 
 - **Configure Redis maxmemory** policy:
   ```yaml

--- a/packages/hermes-api/.env.example
+++ b/packages/hermes-api/.env.example
@@ -37,8 +37,6 @@ HERMES_DEV_PORT=5173
 # =============================================================================
 
 # Database connection URL
-# Development: sqlite+aiosqlite:///./data/hermes.db
-# Production: postgresql+asyncpg://user:password@db:5432/hermes
 HERMES_DATABASE_URL=sqlite+aiosqlite:///./data/hermes.db
 
 # Enable SQL query logging (development only)
@@ -145,32 +143,3 @@ HERMES_TEMP_DIR=/app/temp
 # - Separate domain: https://hermes-api.example.com/api/v1
 # - Development: leave as /api/v1 (uses Docker proxy)
 VITE_API_BASE_URL=/api/v1
-
-# =============================================================================
-# DEVELOPMENT SETUP
-# =============================================================================
-
-# For development with Docker Compose:
-# 1. Copy this file: cp .env.example .env
-# 2. Generate secret key: python3 -c "import secrets; print(secrets.token_urlsafe(32))"
-# 3. Run: docker compose -f docker-compose.dev.yml up
-
-# =============================================================================
-# PRODUCTION SETUP EXAMPLES
-# =============================================================================
-
-# Example 1: Single Domain (hermes.example.com)
-# HERMES_DEBUG=false
-# HERMES_SECRET_KEY=your-secure-production-key
-# HERMES_DATABASE_URL=postgresql+asyncpg://user:password@db:5432/hermes
-# HERMES_REDIS_URL=redis://redis:6379/0
-# HERMES_ALLOWED_ORIGINS=["https://hermes.example.com"]
-# VITE_API_BASE_URL=/api/v1
-
-# Example 2: Separate Domains (hermes.example.com + hermes-api.example.com)
-# HERMES_DEBUG=false  
-# HERMES_SECRET_KEY=your-secure-production-key
-# HERMES_DATABASE_URL=postgresql+asyncpg://user:password@db:5432/hermes
-# HERMES_REDIS_URL=redis://redis:6379/0
-# HERMES_ALLOWED_ORIGINS=["https://hermes.example.com","https://hermes-api.example.com"]
-# VITE_API_BASE_URL=https://hermes-api.example.com/api/v1

--- a/packages/hermes-api/README.md
+++ b/packages/hermes-api/README.md
@@ -222,7 +222,7 @@ docker build -f docker/Dockerfile -t hermes-api:latest .
 docker run -d \
   -p 8000:8000 \
   -e HERMES_SECRET_KEY=your-secret-key \
-  -e HERMES_DATABASE_URL=postgresql+asyncpg://user:pass@db/hermes \
+  -e HERMES_DATABASE_URL=sqlite+aiosqlite:///./data/hermes.db \
   -v $(pwd)/downloads:/app/downloads \
   -v $(pwd)/temp:/app/temp \
   -v $(pwd)/data:/app/data \

--- a/packages/hermes-app/.env.example
+++ b/packages/hermes-app/.env.example
@@ -29,9 +29,6 @@ API_VERSION=1.0.0
 # ==============================================================================
 
 # Database connection URL
-# SQLite (development): sqlite+aiosqlite:///./data/hermes.db
-# PostgreSQL (production): postgresql+asyncpg://user:password@db:5432/hermes
-# MySQL (production): mysql+asyncpg://user:password@db:3306/hermes
 HERMES_DATABASE_URL=sqlite+aiosqlite:///./data/hermes.db
 
 # Enable SQL query logging (development only)
@@ -176,7 +173,6 @@ VITE_API_BASE_URL=/api/v1
 # Production with PostgreSQL and Redis
 # HERMES_DEBUG=false
 # HERMES_SECRET_KEY=your-secure-production-key
-# HERMES_DATABASE_URL=postgresql+asyncpg://user:password@db:5432/hermes
 # HERMES_REDIS_URL=redis://redis:6379/0
 # HERMES_RATE_LIMIT_PER_MINUTE=30
 # HERMES_ALLOWED_ORIGINS=https://hermes.example.com,https://hermes-api.example.com


### PR DESCRIPTION
This pull request updates the documentation and example environment files to clarify that only SQLite is currently supported as the database backend for Hermes, removing references to PostgreSQL and MySQL configuration. The changes also update production guidance, backup instructions, and environment file comments to reflect this limitation and provide recommendations for SQLite usage in production.

**Database backend clarification:**

* Updated `docs/CONFIGURATION.md`, `docs/DEPLOYMENT.md`, and example `.env.example` files to state that only SQLite (with `aiosqlite`) is supported, removing references to PostgreSQL and MySQL. [[1]](diffhunk://#diff-58f184d7415a8c22e56e4908527cfd1c7c28ea1c5720cf4280b2d511b25f7409L29-R29) [[2]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL41) [[3]](diffhunk://#diff-0f82469412657df65d0c0e73c22d5c5758c35ead8705a652c54962c0f1376ecfL40-L41) [[4]](diffhunk://#diff-579a6fee7bc9e92fb11bc66e91a54681b865ad0affad78203057c21474e7f1d8L32-L34)

* Revised production setup and backup instructions to use SQLite, including updated example commands and recommendations for backing up the SQLite database. [[1]](diffhunk://#diff-58f184d7415a8c22e56e4908527cfd1c7c28ea1c5720cf4280b2d511b25f7409L152-R157) [[2]](diffhunk://#diff-58f184d7415a8c22e56e4908527cfd1c7c28ea1c5720cf4280b2d511b25f7409L169-R169) [[3]](diffhunk://#diff-ea9864292e6e392d0c8edbabfe41014d61d6ebd2e08f34d8ae21bf9d070fb274L100-R100) [[4]](diffhunk://#diff-ea9864292e6e392d0c8edbabfe41014d61d6ebd2e08f34d8ae21bf9d070fb274L181-R186)

**Documentation and guidance updates:**

* Removed detailed multi-database production setup examples and Docker Compose instructions from `.env.example` files, simplifying guidance to focus on SQLite. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL173-L201) [[2]](diffhunk://#diff-0f82469412657df65d0c0e73c22d5c5758c35ead8705a652c54962c0f1376ecfL148-L176) [[3]](diffhunk://#diff-579a6fee7bc9e92fb11bc66e91a54681b865ad0affad78203057c21474e7f1d8L179)

* Updated deployment best practices to recommend regular SQLite backups and clarified that production deployments should consider SQLite limitations. [[1]](diffhunk://#diff-ea9864292e6e392d0c8edbabfe41014d61d6ebd2e08f34d8ae21bf9d070fb274L54-R54) [[2]](diffhunk://#diff-ea9864292e6e392d0c8edbabfe41014d61d6ebd2e08f34d8ae21bf9d070fb274L387-R388)

* Added explicit notes in troubleshooting sections that only SQLite is supported, removing PostgreSQL troubleshooting steps.

**Docker and README updates:**

* Changed Docker run and build command examples to use the SQLite database URL instead of PostgreSQL.

These changes ensure that users are not misled about database support and have clear, accurate instructions for deploying Hermes with SQLite.

#40 - Fixes for now. 