### PR TITLE
[codex] Hide signup link when signup is disabled

### DIFF
--- a/packages/hermes-app/src/routes/auth.login.tsx
+++ b/packages/hermes-app/src/routes/auth.login.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
@@ -10,13 +10,29 @@ import { Loader2 } from 'lucide-react'
 import { useAuth } from '@/contexts/AuthContext'
 import { toast } from 'sonner'
 import { HermesLogoLight } from '@/components/hermes-logo'
+import { configService } from '@/services/config'
 
 function LoginPage() {
   const [identifier, setIdentifier] = useState('') // Can be username or email
   const [password, setPassword] = useState('')
   const [isLoading, setIsLoading] = useState(false)
+  const [allowPublicSignup, setAllowPublicSignup] = useState(true)
   const { login } = useAuth()
   const navigate = useNavigate()
+
+  useEffect(() => {
+    const checkSignupStatus = async () => {
+      try {
+        const config = await configService.getPublicConfig()
+        setAllowPublicSignup(config.allowPublicSignup)
+      } catch (error) {
+        console.error('[Login] Failed to fetch public config:', error)
+        setAllowPublicSignup(true)
+      }
+    }
+
+    checkSignupStatus()
+  }, [])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -103,26 +119,30 @@ function LoginPage() {
           </form>
         </CardContent>
         <CardFooter className="flex flex-col space-y-4">
-          <div className="relative w-full">
-            <div className="absolute inset-0 flex items-center">
-              <Separator />
-            </div>
-            <div className="relative flex justify-center text-xs uppercase">
-              <span className="bg-background px-2 text-muted-foreground">
-                Or
-              </span>
-            </div>
-          </div>
-          <div className="text-center text-sm text-muted-foreground">
-            Don&apos;t have an account?{' '}
-            <Button
-              variant="link"
-              className="px-0 font-normal"
-              onClick={() => navigate({ to: '/auth/signup' })}
-            >
-              Sign up
-            </Button>
-          </div>
+          {allowPublicSignup && (
+            <>
+              <div className="relative w-full">
+                <div className="absolute inset-0 flex items-center">
+                  <Separator />
+                </div>
+                <div className="relative flex justify-center text-xs uppercase">
+                  <span className="bg-background px-2 text-muted-foreground">
+                    Or
+                  </span>
+                </div>
+              </div>
+              <div className="text-center text-sm text-muted-foreground">
+                Don&apos;t have an account?{' '}
+                <Button
+                  variant="link"
+                  className="px-0 font-normal"
+                  onClick={() => navigate({ to: '/auth/signup' })}
+                >
+                  Sign up
+                </Button>
+              </div>
+            </>
+          )}
         </CardFooter>
       </Card>
     </div>

--- a/packages/hermes-app/src/services/config.ts
+++ b/packages/hermes-app/src/services/config.ts
@@ -6,6 +6,11 @@ export interface PublicConfig {
   allowPublicSignup: boolean
 }
 
+interface PublicConfigResponse {
+  allowPublicSignup?: boolean
+  allow_public_signup?: boolean
+}
+
 class ConfigService {
   private baseURL: string
 
@@ -29,11 +34,10 @@ class ConfigService {
         throw new Error(`HTTP ${response.status}: ${errorData.detail || response.statusText}`)
       }
 
-      const data = await response.json()
+      const data = await response.json() as PublicConfigResponse
 
-      // Convert snake_case to camelCase
       return {
-        allowPublicSignup: data.allow_public_signup,
+        allowPublicSignup: data.allowPublicSignup ?? data.allow_public_signup ?? true,
       }
     } catch (error) {
       console.error('[ConfigService] Failed to fetch public config:', error)


### PR DESCRIPTION
## Summary
- Fetch public config on the login page
- Hide the signup separator/link when public signup is disabled
- Leave existing backend signup controls unchanged

## Validation
- uv run pytest tests/test_services/test_system_settings_service.py tests/test_api/test_signup_restrictions.py
- pnpm --dir packages/hermes-app run type-check

Fixes #43