### PR TITLE
[codex] Fix API schema type generation

### DIFF
--- a/packages/hermes-api/app/api/v1/endpoints/health.py
+++ b/packages/hermes-api/app/api/v1/endpoints/health.py
@@ -11,12 +11,12 @@ from sqlalchemy import text
 
 from app.core.config import settings
 from app.db.base import engine
-from app.models.pydantic.response import HealthResponse
+from app.models.pydantic.response import DetailedHealthResponse, HealthResponse
 
 router = APIRouter()
 
 
-@router.get("/")
+@router.get("/", response_model=HealthResponse)
 async def get_health():
     """Get API health status."""
     return HealthResponse(
@@ -27,12 +27,12 @@ async def get_health():
     )
 
 
-@router.get("/detailed")
+@router.get("/detailed", response_model=DetailedHealthResponse)
 async def get_detailed_health():
     """Get detailed health information including dependencies."""
     health_info = {
         "status": "healthy",
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": datetime.now(timezone.utc),
         "version": settings.api_version,
         "environment": "development" if settings.debug else "production",
         "dependencies": {},

--- a/packages/hermes-api/app/api/v1/endpoints/timeline.py
+++ b/packages/hermes-api/app/api/v1/endpoints/timeline.py
@@ -14,7 +14,7 @@ from app.core.logging import get_logger
 from app.core.security import get_current_api_key
 from app.db.models import DownloadHistory as DownloadHistoryModel
 from app.db.session import get_database_session
-from app.models.pydantic.history import DailyStats
+from app.models.pydantic.history import DailyStats, TimelineSummary
 
 router = APIRouter(prefix="/timeline", tags=["timeline"])
 logger = get_logger(__name__)
@@ -126,7 +126,7 @@ async def get_timeline_stats(
         )
 
 
-@router.get("/summary", response_model=dict)
+@router.get("/summary", response_model=TimelineSummary)
 async def get_timeline_summary(
     period: str = Query("week", description="Time period (day, week, month, year)"),
     start_date: Optional[date_type] = Query(
@@ -148,20 +148,24 @@ async def get_timeline_summary(
             period=period,
             start_date=start_date,
             end_date=end_date,
+            extractor=None,
+            status=None,
             db_session=db_session,
             api_key=api_key,
         )
 
         if not daily_stats:
-            return {
-                "total_downloads": 0,
-                "success_rate": 0.0,
-                "total_size": 0,
-                "avg_daily_downloads": 0,
-                "trend": "stable",
-                "peak_day": None,
-                "period": period,
-            }
+            return TimelineSummary(
+                total_downloads=0,
+                success_rate=0.0,
+                total_size=0,
+                avg_daily_downloads=0,
+                trend="stable",
+                peak_day=None,
+                peak_downloads=0,
+                period=period,
+                days_count=0,
+            )
 
         # Calculate summary statistics
         total_downloads = sum(stat.downloads for stat in daily_stats)
@@ -196,17 +200,17 @@ async def get_timeline_summary(
         else:
             trend = "stable"
 
-        return {
-            "total_downloads": total_downloads,
-            "success_rate": round(success_rate, 3),
-            "total_size": total_size,
-            "avg_daily_downloads": round(avg_daily_downloads, 2),
-            "trend": trend,
-            "peak_day": peak_day.date.isoformat() if peak_day else None,
-            "peak_downloads": peak_day.downloads if peak_day else 0,
-            "period": period,
-            "days_count": len(daily_stats),
-        }
+        return TimelineSummary(
+            total_downloads=total_downloads,
+            success_rate=round(success_rate, 3),
+            total_size=total_size,
+            avg_daily_downloads=round(avg_daily_downloads, 2),
+            trend=trend,
+            peak_day=peak_day.date.isoformat() if peak_day else None,
+            peak_downloads=peak_day.downloads if peak_day else 0,
+            period=period,
+            days_count=len(daily_stats),
+        )
 
     except Exception as e:
         logger.error("Failed to get timeline summary", error=str(e))

--- a/packages/hermes-api/app/models/pydantic/history.py
+++ b/packages/hermes-api/app/models/pydantic/history.py
@@ -4,7 +4,7 @@ Pydantic models for download history and statistics.
 
 from datetime import date as date_type
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from pydantic import Field
 
@@ -33,6 +33,22 @@ class DailyStats(CamelCaseModel):
     downloads: int = Field(..., description="Number of downloads")
     success_rate: float = Field(..., description="Success rate (0.0 to 1.0)")
     total_size: int = Field(0, description="Total bytes downloaded")
+
+
+class TimelineSummary(CamelCaseModel):
+    """Summary statistics for timeline analytics."""
+
+    total_downloads: int = Field(..., description="Total downloads in the period")
+    success_rate: float = Field(..., description="Success rate (0.0 to 1.0)")
+    total_size: int = Field(..., description="Total bytes downloaded")
+    avg_daily_downloads: float = Field(..., description="Average downloads per day")
+    trend: Literal["increasing", "decreasing", "stable"] = Field(
+        ..., description="Download trend over the period"
+    )
+    peak_day: Optional[str] = Field(None, description="Date with the most downloads")
+    peak_downloads: int = Field(..., description="Downloads on the peak day")
+    period: str = Field(..., description="Requested period")
+    days_count: int = Field(..., description="Number of days represented")
 
 
 class PopularExtractor(CamelCaseModel):

--- a/packages/hermes-api/app/models/pydantic/response.py
+++ b/packages/hermes-api/app/models/pydantic/response.py
@@ -19,6 +19,24 @@ class HealthResponse(CamelCaseModel):
     environment: str = Field(..., description="Current environment")
 
 
+class HealthDependency(CamelCaseModel):
+    """Health status for an external dependency."""
+
+    status: str = Field(..., description="Dependency status")
+    message: str = Field(..., description="Dependency status message")
+    response_time_ms: Optional[float] = Field(
+        None, description="Dependency response time in milliseconds"
+    )
+
+
+class DetailedHealthResponse(HealthResponse):
+    """Detailed API health status including dependencies."""
+
+    dependencies: Dict[str, HealthDependency] = Field(
+        default_factory=dict, description="Health status by dependency name"
+    )
+
+
 class FormatDetail(CamelCaseModel):
     """Detailed format information."""
 

--- a/packages/hermes-api/scripts/export_openapi.py
+++ b/packages/hermes-api/scripts/export_openapi.py
@@ -1,0 +1,22 @@
+"""Export the FastAPI OpenAPI schema without starting a server."""
+
+import json
+import sys
+from pathlib import Path
+
+from app.main import app
+
+
+def main() -> None:
+    schema = app.openapi()
+    output = json.dumps(schema, indent=2) + "\n"
+
+    if len(sys.argv) > 1:
+        Path(sys.argv[1]).write_text(output)
+        return
+
+    sys.stdout.write(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/hermes-api/tests/test_api/test_health.py
+++ b/packages/hermes-api/tests/test_api/test_health.py
@@ -29,3 +29,6 @@ class TestHealth:
         assert "dependencies" in data
         assert "database" in data["dependencies"]
         assert "redis" in data["dependencies"]
+        assert "response_time_ms" not in data["dependencies"]["database"]
+        if "responseTimeMs" in data["dependencies"]["database"]:
+            assert isinstance(data["dependencies"]["database"]["responseTimeMs"], float)

--- a/packages/hermes-api/tests/test_api/test_openapi_schema.py
+++ b/packages/hermes-api/tests/test_api/test_openapi_schema.py
@@ -10,6 +10,34 @@ import pytest
 class TestOpenAPISchema:
     """Test OpenAPI schema conventions."""
 
+    def _find_snake_case_fields(self, node, path="schema"):
+        """Find snake_case property names anywhere in an OpenAPI schema node."""
+        errors = []
+
+        if isinstance(node, dict):
+            properties = node.get("properties", {})
+            if isinstance(properties, dict):
+                for field_name, field_schema in properties.items():
+                    if "_" in field_name and not field_name.startswith("__"):
+                        errors.append(f"{path}.{field_name}")
+                    errors.extend(
+                        self._find_snake_case_fields(
+                            field_schema, f"{path}.{field_name}"
+                        )
+                    )
+
+            for key in ("items", "additionalProperties", "allOf", "anyOf", "oneOf"):
+                value = node.get(key)
+                if isinstance(value, list):
+                    for index, item in enumerate(value):
+                        errors.extend(
+                            self._find_snake_case_fields(item, f"{path}.{key}[{index}]")
+                        )
+                elif value is not None:
+                    errors.extend(self._find_snake_case_fields(value, f"{path}.{key}"))
+
+        return errors
+
     @pytest.mark.asyncio
     async def test_all_fields_use_camelcase(self):
         """Test that all OpenAPI schema fields use camelCase (not snake_case)."""
@@ -22,11 +50,45 @@ class TestOpenAPISchema:
         for schema_name, schema_def in (
             schema.get("components", {}).get("schemas", {}).items()
         ):
-            properties = schema_def.get("properties", {})
-            for field_name in properties.keys():
-                # Check for snake_case (has underscore)
-                if "_" in field_name and not field_name.startswith("__"):
-                    errors.append(f"{schema_name}.{field_name}")
+            errors.extend(self._find_snake_case_fields(schema_def, schema_name))
+
+        # Also check inline schemas on path responses and request bodies. Plain
+        # dict response models otherwise bypass component-level validation.
+        for route_path, path_def in schema.get("paths", {}).items():
+            for method, operation in path_def.items():
+                if method not in {
+                    "get",
+                    "put",
+                    "post",
+                    "delete",
+                    "options",
+                    "head",
+                    "patch",
+                    "trace",
+                }:
+                    continue
+
+                for status_code, response in operation.get("responses", {}).items():
+                    for media_type, media in response.get("content", {}).items():
+                        schema_def = media.get("schema")
+                        if schema_def:
+                            errors.extend(
+                                self._find_snake_case_fields(
+                                    schema_def,
+                                    f"{method.upper()} {route_path} {status_code} {media_type}",
+                                )
+                            )
+
+                request_body = operation.get("requestBody", {})
+                for media_type, media in request_body.get("content", {}).items():
+                    schema_def = media.get("schema")
+                    if schema_def:
+                        errors.extend(
+                            self._find_snake_case_fields(
+                                schema_def,
+                                f"{method.upper()} {route_path} request {media_type}",
+                            )
+                        )
 
         if errors:
             error_list = "\n  - ".join(errors[:10])

--- a/packages/hermes-api/tests/test_api/test_timeline.py
+++ b/packages/hermes-api/tests/test_api/test_timeline.py
@@ -1,0 +1,80 @@
+"""Tests for timeline analytics endpoints."""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import DownloadHistory
+
+
+class TestTimeline:
+    """Test cases for timeline endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_timeline_stats_uses_camelcase_fields(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Timeline stats should serialize DailyStats with API camelCase aliases."""
+        completed_at = datetime.now(timezone.utc)
+        db_session.add(
+            DownloadHistory(
+                id=str(uuid.uuid4()),
+                download_id=str(uuid.uuid4()),
+                url="https://example.com/video",
+                status="completed",
+                duration=10.0,
+                file_size=2048,
+                extractor="youtube",
+                started_at=completed_at - timedelta(seconds=10),
+                completed_at=completed_at,
+            )
+        )
+        await db_session.commit()
+
+        response = await client.get("/api/v1/timeline/")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["successRate"] == 1.0
+        assert data[0]["totalSize"] == 2048
+        assert "success_rate" not in data[0]
+        assert "total_size" not in data[0]
+
+    @pytest.mark.asyncio
+    async def test_timeline_summary_uses_camelcase_fields(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Timeline summary should expose the typed camelCase API contract."""
+        completed_at = datetime.now(timezone.utc)
+        db_session.add(
+            DownloadHistory(
+                id=str(uuid.uuid4()),
+                download_id=str(uuid.uuid4()),
+                url="https://example.com/video",
+                status="completed",
+                duration=10.0,
+                file_size=4096,
+                extractor="youtube",
+                started_at=completed_at - timedelta(seconds=10),
+                completed_at=completed_at,
+            )
+        )
+        await db_session.commit()
+
+        response = await client.get("/api/v1/timeline/summary")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["totalDownloads"] == 1
+        assert data["successRate"] == 1.0
+        assert data["totalSize"] == 4096
+        assert data["avgDailyDownloads"] == 1.0
+        assert data["peakDownloads"] == 1
+        assert data["daysCount"] == 1
+        assert "total_downloads" not in data
+        assert "success_rate" not in data
+        assert "avg_daily_downloads" not in data

--- a/packages/hermes-app/package.json
+++ b/packages/hermes-app/package.json
@@ -24,7 +24,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "knip": "knip",
-    "generate:types": "openapi-typescript http://localhost:8000/openapi.json -o ./src/types/api.generated.ts",
+    "generate:types": "node ./scripts/generate-openapi-types.mjs",
     "generate:routes": "tsr generate"
   },
   "devDependencies": {

--- a/packages/hermes-app/scripts/generate-openapi-types.mjs
+++ b/packages/hermes-app/scripts/generate-openapi-types.mjs
@@ -1,0 +1,39 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import process from 'node:process'
+
+const appDir = resolve(import.meta.dirname, '..')
+const repoRoot = resolve(appDir, '../..')
+const apiDir = join(repoRoot, 'packages/hermes-api')
+const outputPath = join(appDir, 'src/types/api.generated.ts')
+const tempDir = mkdtempSync(join(tmpdir(), 'hermes-openapi-types-'))
+const schemaPath = join(tempDir, 'openapi.json')
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    stdio: 'inherit',
+    env: process.env,
+    ...options,
+  })
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1)
+  }
+}
+
+try {
+  run('uv', ['run', 'python', 'scripts/export_openapi.py', schemaPath], {
+    cwd: apiDir,
+    env: {
+      ...process.env,
+      HERMES_SECRET_KEY: process.env.HERMES_SECRET_KEY ?? 'openapi-schema-export',
+    },
+  })
+  run('pnpm', ['exec', 'openapi-typescript', schemaPath, '-o', outputPath], {
+    cwd: appDir,
+  })
+} finally {
+  rmSync(tempDir, { recursive: true, force: true })
+}

--- a/packages/hermes-app/src/components/queue/QueueCharts.tsx
+++ b/packages/hermes-app/src/components/queue/QueueCharts.tsx
@@ -51,8 +51,8 @@ export function QueueCharts() {
   const chartData = timelineData?.map(item => ({
     date: new Date(item.date).toLocaleDateString(),
     downloads: item.downloads,
-    successRate: Math.round(item.success_rate * 100),
-    totalSize: Math.round(item.total_size / 1024 / 1024), // Convert to MB
+    successRate: Math.round(item.successRate * 100),
+    totalSize: Math.round(item.totalSize / 1024 / 1024), // Convert to MB
   })) || []
 
   // Transform stats data for extractor pie chart
@@ -108,7 +108,7 @@ export function QueueCharts() {
               <CardTitle className="text-sm font-medium text-muted-foreground">Total Downloads</CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold">{timelineSummary.total_downloads}</div>
+              <div className="text-2xl font-bold">{timelineSummary.totalDownloads}</div>
               <div className="flex items-center gap-1 text-xs text-muted-foreground">
                 {timelineSummary.trend === 'increasing' ? (
                   <TrendingUp className="h-3 w-3 text-green-500" />
@@ -117,7 +117,7 @@ export function QueueCharts() {
                 ) : (
                   <Activity className="h-3 w-3 text-gray-500" />
                 )}
-                {timelineSummary.trend} over {timelineSummary.days_count} days
+                {timelineSummary.trend} over {timelineSummary.daysCount} days
               </div>
             </CardContent>
           </Card>
@@ -127,9 +127,9 @@ export function QueueCharts() {
               <CardTitle className="text-sm font-medium text-muted-foreground">Success Rate</CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold">{Math.round(timelineSummary.success_rate * 100)}%</div>
+              <div className="text-2xl font-bold">{Math.round(timelineSummary.successRate * 100)}%</div>
               <div className="text-xs text-muted-foreground">
-                {timelineSummary.total_downloads} downloads
+                {timelineSummary.totalDownloads} downloads
               </div>
             </CardContent>
           </Card>
@@ -139,7 +139,7 @@ export function QueueCharts() {
               <CardTitle className="text-sm font-medium text-muted-foreground">Daily Average</CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold">{timelineSummary.avg_daily_downloads}</div>
+              <div className="text-2xl font-bold">{timelineSummary.avgDailyDownloads}</div>
               <div className="text-xs text-muted-foreground">
                 downloads per day
               </div>
@@ -151,9 +151,9 @@ export function QueueCharts() {
               <CardTitle className="text-sm font-medium text-muted-foreground">Peak Day</CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold">{timelineSummary.peak_downloads}</div>
+              <div className="text-2xl font-bold">{timelineSummary.peakDownloads}</div>
               <div className="text-xs text-muted-foreground">
-                {timelineSummary.peak_day ? new Date(timelineSummary.peak_day).toLocaleDateString() : 'No data'}
+                {timelineSummary.peakDay ? new Date(timelineSummary.peakDay).toLocaleDateString() : 'No data'}
               </div>
             </CardContent>
           </Card>

--- a/packages/hermes-app/src/services/api/client.ts
+++ b/packages/hermes-app/src/services/api/client.ts
@@ -3,33 +3,9 @@
 import type { components } from '@/types/api.generated'
 
 type VideoInfo = components["schemas"]["VideoInfo"]
-
-// Define types for API responses that aren't in the schema
-interface HealthResponse {
-  status: string
-  timestamp: string
-  version: string
-  environment: string
-}
-
-interface DailyStats {
-  date: string
-  downloads: number
-  success_rate: number
-  total_size: number
-}
-
-interface TimelineSummary {
-  total_downloads: number
-  success_rate: number
-  total_size: number
-  avg_daily_downloads: number
-  trend: string
-  peak_day: string | null
-  peak_downloads: number
-  period: string
-  days_count: number
-}
+type HealthResponse = components["schemas"]["HealthResponse"]
+type DailyStats = components["schemas"]["DailyStats"]
+type TimelineSummary = components["schemas"]["TimelineSummary"]
 type DownloadRequest = components["schemas"]["DownloadRequest"]
 type DownloadResponse = components["schemas"]["DownloadResponse"]
 type DownloadStatus = components["schemas"]["DownloadStatus"]
@@ -189,7 +165,7 @@ class ApiClient {
 
   // Download management
   async startDownload(request: DownloadRequest): Promise<DownloadResponse> {
-    return this.request<DownloadResponse>('/download', {
+    return this.request<DownloadResponse>('/download/', {
       method: 'POST',
       body: JSON.stringify(request),
     })
@@ -311,11 +287,11 @@ class ApiClient {
 
   // Storage management
   async getStorageInfo(): Promise<StorageInfo> {
-    return this.request<StorageInfo>('/storage')
+    return this.request<StorageInfo>('/storage/')
   }
 
   async cleanupDownloads(request: CleanupRequest): Promise<CleanupResponse> {
-    return this.request<CleanupResponse>('/cleanup', {
+    return this.request<CleanupResponse>('/cleanup/', {
       method: 'POST',
       body: JSON.stringify(request),
     })
@@ -323,7 +299,7 @@ class ApiClient {
 
   // Formats
   async getAvailableFormats(): Promise<FormatInfo> {
-    return this.request<FormatInfo>('/formats')
+    return this.request<FormatInfo>('/formats/')
   }
 
   // Configuration

--- a/packages/hermes-app/src/types/api.generated.ts
+++ b/packages/hermes-app/src/types/api.generated.ts
@@ -1880,6 +1880,40 @@ export interface components {
             totalFreedSpace: number;
         };
         /**
+         * DetailedHealthResponse
+         * @description Detailed API health status including dependencies.
+         */
+        DetailedHealthResponse: {
+            /**
+             * Status
+             * @description Health status
+             */
+            status: string;
+            /**
+             * Timestamp
+             * Format: date-time
+             * @description Response timestamp
+             */
+            timestamp: string;
+            /**
+             * Version
+             * @description API version
+             */
+            version: string;
+            /**
+             * Environment
+             * @description Current environment
+             */
+            environment: string;
+            /**
+             * Dependencies
+             * @description Health status by dependency name
+             */
+            dependencies?: {
+                [key: string]: components["schemas"]["HealthDependency"];
+            };
+        };
+        /**
          * DownloadHistory
          * @description Complete download history with statistics.
          */
@@ -2457,6 +2491,54 @@ export interface components {
             detail?: components["schemas"]["ValidationError"][];
         };
         /**
+         * HealthDependency
+         * @description Health status for an external dependency.
+         */
+        HealthDependency: {
+            /**
+             * Status
+             * @description Dependency status
+             */
+            status: string;
+            /**
+             * Message
+             * @description Dependency status message
+             */
+            message: string;
+            /**
+             * Responsetimems
+             * @description Dependency response time in milliseconds
+             */
+            responseTimeMs?: number | null;
+        };
+        /**
+         * HealthResponse
+         * @description Response model for health check.
+         */
+        HealthResponse: {
+            /**
+             * Status
+             * @description Health status
+             */
+            status: string;
+            /**
+             * Timestamp
+             * Format: date-time
+             * @description Response timestamp
+             */
+            timestamp: string;
+            /**
+             * Version
+             * @description API version
+             */
+            version: string;
+            /**
+             * Environment
+             * @description Current environment
+             */
+            environment: string;
+        };
+        /**
          * HistoryItem
          * @description Individual history record.
          */
@@ -2740,6 +2822,58 @@ export interface components {
             resolution?: string | null;
         };
         /**
+         * TimelineSummary
+         * @description Summary statistics for timeline analytics.
+         */
+        TimelineSummary: {
+            /**
+             * Totaldownloads
+             * @description Total downloads in the period
+             */
+            totalDownloads: number;
+            /**
+             * Successrate
+             * @description Success rate (0.0 to 1.0)
+             */
+            successRate: number;
+            /**
+             * Totalsize
+             * @description Total bytes downloaded
+             */
+            totalSize: number;
+            /**
+             * Avgdailydownloads
+             * @description Average downloads per day
+             */
+            avgDailyDownloads: number;
+            /**
+             * Trend
+             * @description Download trend over the period
+             * @enum {string}
+             */
+            trend: "increasing" | "decreasing" | "stable";
+            /**
+             * Peakday
+             * @description Date with the most downloads
+             */
+            peakDay?: string | null;
+            /**
+             * Peakdownloads
+             * @description Downloads on the peak day
+             */
+            peakDownloads: number;
+            /**
+             * Period
+             * @description Requested period
+             */
+            period: string;
+            /**
+             * Dayscount
+             * @description Number of days represented
+             */
+            daysCount: number;
+        };
+        /**
          * TokenResponse
          * @description Token response with automatic camelCase conversion.
          */
@@ -2879,6 +3013,10 @@ export interface components {
             msg: string;
             /** Error Type */
             type: string;
+            /** Input */
+            input?: unknown;
+            /** Context */
+            ctx?: Record<string, never>;
         };
         /**
          * VideoInfo
@@ -2992,7 +3130,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["HealthResponse"];
                 };
             };
         };
@@ -3012,7 +3150,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["DetailedHealthResponse"];
                 };
             };
         };
@@ -3934,9 +4072,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["TimelineSummary"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary
- add explicit OpenAPI response models for health and timeline summary endpoints
- strengthen schema convention coverage so inline response schemas cannot bypass camelCase checks
- fix timeline summary's internal stats call so FastAPI Query defaults do not leak into database filters
- make frontend type generation deterministic by exporting OpenAPI locally instead of requiring a live API server
- update frontend consumers to use generated camelCase API types

## Validation
- uv run pytest tests/test_api/test_openapi_schema.py tests/test_api/test_health.py tests/test_api/test_timeline.py
- uv run black --check app/ tests/ scripts/
- uv run isort --check-only app/ tests/ scripts/
- uv run ruff check app/ tests/ scripts/
- pnpm --filter hermes-app generate:types
- pnpm --filter hermes-app type-check
- pnpm --filter hermes-app lint