### PR TITLE
[codex] Fix frontend auth token refresh

### DIFF
--- a/packages/hermes-app/src/contexts/AuthContext.tsx
+++ b/packages/hermes-app/src/contexts/AuthContext.tsx
@@ -23,13 +23,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           const userData = await authService.getCurrentUser()
           setUser(userData)
           console.log('[AuthContext] Token validated successfully:', userData.username)
+        } else if (TokenStorage.getRefreshToken()) {
+          await authService.refreshToken()
+          const userData = await authService.getCurrentUser()
+          setUser(userData)
+          console.log('[AuthContext] Token refreshed and validated successfully')
         } else {
           console.log('[AuthContext] No token found, user not authenticated')
         }
       } catch (error) {
         console.error('[AuthContext] Token validation failed:', error)
-        // Clear invalid tokens
-        TokenStorage.clearTokens()
         setUser(null)
 
         // Attempt token refresh if 401 error
@@ -42,7 +45,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             console.log('[AuthContext] Token refreshed and validated successfully')
           } catch (refreshError) {
             console.error('[AuthContext] Token refresh failed:', refreshError)
+            TokenStorage.clearTokens()
           }
+        } else {
+          TokenStorage.clearTokens()
         }
       } finally {
         setIsValidating(false)

--- a/packages/hermes-app/src/services/__tests__/apiClient.test.ts
+++ b/packages/hermes-app/src/services/__tests__/apiClient.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { apiClient } from '../api/client'
+import { TokenStorage } from '@/utils/tokenStorage'
 
 // Mock fetch
 global.fetch = vi.fn()
@@ -121,6 +122,62 @@ describe('ApiClient - API Key Methods', () => {
       } as Response)
 
       await expect(apiClient.getApiKeys()).rejects.toThrow('403: Access denied')
+    })
+
+    it('should retry 401 responses with the refreshed access token', async () => {
+      const mockApiKeys = [
+        {
+          id: '1',
+          name: 'Test Key',
+          permissions: ['read'],
+          rate_limit: 60,
+          is_active: true,
+          created_at: '2025-01-01T00:00:00Z',
+          last_used: null,
+          expires_at: null,
+        },
+      ]
+
+      vi.spyOn(TokenStorage, 'getAccessToken').mockReturnValue('fresh-token')
+      vi.spyOn(TokenStorage, 'getRefreshToken').mockReturnValue('refresh-token')
+      vi.spyOn(TokenStorage, 'setAccessToken').mockImplementation(() => {})
+      vi.spyOn(TokenStorage, 'setRefreshToken').mockImplementation(() => {})
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 401,
+          statusText: 'Unauthorized',
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            accessToken: 'fresh-token',
+            refreshToken: 'fresh-refresh-token',
+            tokenType: 'bearer',
+          }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => mockApiKeys,
+        } as Response)
+
+      const result = await apiClient.request<typeof mockApiKeys>('/auth/api-keys', {
+        headers: {
+          Authorization: 'Bearer expired-token',
+        },
+      })
+
+      expect(result).toEqual(mockApiKeys)
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        3,
+        '/api/v1/auth/api-keys',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer fresh-token',
+          }),
+        })
+      )
     })
   })
 

--- a/packages/hermes-app/src/services/api/client.ts
+++ b/packages/hermes-app/src/services/api/client.ts
@@ -126,8 +126,8 @@ class ApiClient {
         // Retry request with new token
         const newHeaders = await this.getAuthHeaders()
         fetchOptions.headers = {
-          ...newHeaders,
           ...fetchOptions.headers,
+          ...newHeaders,
         }
 
         const retryResponse = await fetch(url, fetchOptions)
@@ -138,8 +138,7 @@ class ApiClient {
         return retryResponse.json()
       } catch (refreshError) {
         // Refresh failed, redirect to login
-        localStorage.removeItem('accessToken')
-        localStorage.removeItem('refreshToken')
+        TokenStorage.clearTokens()
         window.location.href = '/auth/login'
         throw this.handleAuthError(refreshError)
       }

--- a/packages/hermes-app/src/utils/__tests__/tokenStorage.test.ts
+++ b/packages/hermes-app/src/utils/__tests__/tokenStorage.test.ts
@@ -33,7 +33,11 @@ describe('TokenStorage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorageMock.getItem.mockReturnValue(null)
+    localStorageMock.setItem.mockImplementation(() => undefined)
+    localStorageMock.removeItem.mockImplementation(() => undefined)
     sessionStorageMock.getItem.mockReturnValue(null)
+    sessionStorageMock.setItem.mockImplementation(() => undefined)
+    sessionStorageMock.removeItem.mockImplementation(() => undefined)
   })
 
   describe('setAccessToken', () => {
@@ -140,7 +144,7 @@ describe('TokenStorage', () => {
       expect(result).toBeNull()
     })
 
-    it('should clear expired tokens', () => {
+    it('should clear only expired access token data', () => {
       const expiredTime = Date.now() - 1000 // 1 second ago
       localStorageMock.getItem
         .mockReturnValueOnce('test-token') // token
@@ -149,9 +153,10 @@ describe('TokenStorage', () => {
       const result = TokenStorage.getAccessToken()
 
       expect(result).toBeNull()
+      expect(sessionStorageMock.removeItem).toHaveBeenCalledWith('hermes_access_token')
       expect(localStorageMock.removeItem).toHaveBeenCalledWith('hermes_access_token')
-      expect(localStorageMock.removeItem).toHaveBeenCalledWith('hermes_refresh_token')
       expect(localStorageMock.removeItem).toHaveBeenCalledWith('hermes_token_expiry')
+      expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('hermes_refresh_token')
     })
 
     it('should handle storage errors and fall back gracefully', () => {
@@ -286,6 +291,17 @@ describe('TokenStorage', () => {
       expect(() => {
         TokenStorage.clearTokens()
       }).not.toThrow()
+    })
+  })
+
+  describe('clearAccessToken', () => {
+    it('should clear access token data without clearing refresh token', () => {
+      TokenStorage.clearAccessToken()
+
+      expect(sessionStorageMock.removeItem).toHaveBeenCalledWith('hermes_access_token')
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith('hermes_access_token')
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith('hermes_token_expiry')
+      expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('hermes_refresh_token')
     })
   })
 

--- a/packages/hermes-app/src/utils/tokenStorage.ts
+++ b/packages/hermes-app/src/utils/tokenStorage.ts
@@ -55,7 +55,7 @@ export class TokenStorage {
         const isExpired = Date.now() > parseInt(expiryTime)
         console.log('[TokenStorage] getAccessToken - expiry check:', { expiryTime: new Date(parseInt(expiryTime)), isExpired })
         if (isExpired) {
-          this.clearTokens()
+          this.clearAccessToken()
           console.log('[TokenStorage] Token expired, cleared automatically')
           return null
         }
@@ -102,6 +102,21 @@ export class TokenStorage {
    * Clear all tokens
    */
   static clearTokens(): void {
+    this.clearAccessToken()
+
+    try {
+      localStorage.removeItem(this.REFRESH_TOKEN_KEY)
+    } catch (error) {
+      console.warn('[TokenStorage] Failed to clear refresh token:', error)
+    }
+
+    console.log('[TokenStorage] All tokens cleared')
+  }
+
+  /**
+   * Clear only the short-lived access token and its client expiry marker.
+   */
+  static clearAccessToken(): void {
     try {
       sessionStorage.removeItem(this.ACCESS_TOKEN_KEY)
     } catch (error) {
@@ -110,13 +125,10 @@ export class TokenStorage {
 
     try {
       localStorage.removeItem(this.ACCESS_TOKEN_KEY)
-      localStorage.removeItem(this.REFRESH_TOKEN_KEY)
       localStorage.removeItem(this.TOKEN_EXPIRY_KEY)
     } catch (error) {
       console.warn('[TokenStorage] Failed to clear localStorage:', error)
     }
-
-    console.log('[TokenStorage] All tokens cleared')
   }
 
   /**


### PR DESCRIPTION
## Summary
- preserve refresh tokens when the client-side access token expires
- refresh on app startup when only a refresh token remains
- retry 401 requests with the newly refreshed Authorization header

## Validation
- pnpm --filter hermes-app test src/utils/__tests__/tokenStorage.test.ts src/services/__tests__/apiClient.test.ts
- pnpm --filter hermes-app type-check