### PR TITLE
[codex] Renew frontend SSE tokens

### DIFF
--- a/packages/hermes-app/src/hooks/useDownloadProgressSSE.ts
+++ b/packages/hermes-app/src/hooks/useDownloadProgressSSE.ts
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSSE } from './useSSE';
-import { apiClient } from '@/services/api/client';
+import { useSSEToken } from './useSSEToken';
 import { getApiBaseUrl } from '@/lib/config';
 import type { components } from '@/types/api.generated';
 
@@ -32,38 +32,11 @@ type DownloadStatus = components["schemas"]["DownloadStatus"];
  */
 export function useDownloadProgressSSE(downloadId: string) {
   const queryClient = useQueryClient();
-  const [sseToken, setSSEToken] = useState<string | null>(null);
-  const [tokenError, setTokenError] = useState<Error | null>(null);
-
-  // Fetch SSE token on mount
-  useEffect(() => {
-    let mounted = true;
-
-    async function fetchSSEToken() {
-      try {
-        const response = await apiClient.createSSEToken({
-          scope: `download:${downloadId}`,
-          ttl: 600, // 10 minutes - enough for most downloads
-        });
-
-        if (mounted) {
-          setSSEToken(response.token);
-          setTokenError(null);
-        }
-      } catch (err) {
-        console.error('Failed to fetch SSE token:', err);
-        if (mounted) {
-          setTokenError(err instanceof Error ? err : new Error('Failed to fetch SSE token'));
-        }
-      }
-    }
-
-    fetchSSEToken();
-
-    return () => {
-      mounted = false;
-    };
-  }, [downloadId]);
+  const { token: sseToken, error: tokenError } = useSSEToken(
+    `download:${downloadId}`,
+    600,
+    'Failed to fetch SSE token:'
+  );
 
   // Build SSE URL with ephemeral token
   const sseUrl = useMemo(() => {

--- a/packages/hermes-app/src/hooks/useQueueUpdatesSSE.ts
+++ b/packages/hermes-app/src/hooks/useQueueUpdatesSSE.ts
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSSE } from './useSSE';
-import { apiClient } from '@/services/api/client';
+import { useSSEToken } from './useSSEToken';
 import { getApiBaseUrl } from '@/lib/config';
 
 export interface QueueUpdate {
@@ -34,38 +34,11 @@ export interface QueueUpdate {
  */
 export function useQueueUpdatesSSE() {
   const queryClient = useQueryClient();
-  const [sseToken, setSSEToken] = useState<string | null>(null);
-  const [tokenError, setTokenError] = useState<Error | null>(null);
-
-  // Fetch SSE token on mount
-  useEffect(() => {
-    let mounted = true;
-
-    async function fetchSSEToken() {
-      try {
-        const response = await apiClient.createSSEToken({
-          scope: 'queue',
-          ttl: 600, // 10 minutes
-        });
-
-        if (mounted) {
-          setSSEToken(response.token);
-          setTokenError(null);
-        }
-      } catch (err) {
-        console.error('Failed to fetch SSE token for queue:', err);
-        if (mounted) {
-          setTokenError(err instanceof Error ? err : new Error('Failed to fetch SSE token'));
-        }
-      }
-    }
-
-    fetchSSEToken();
-
-    return () => {
-      mounted = false;
-    };
-  }, []); // Only fetch once on mount
+  const { token: sseToken, error: tokenError } = useSSEToken(
+    'queue',
+    600,
+    'Failed to fetch SSE token for queue:'
+  );
 
   // Build SSE URL with ephemeral token
   const sseUrl = useMemo(() => {

--- a/packages/hermes-app/src/hooks/useSSEToken.test.ts
+++ b/packages/hermes-app/src/hooks/useSSEToken.test.ts
@@ -1,0 +1,55 @@
+import { renderHook, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSSEToken } from './useSSEToken';
+import { apiClient } from '@/services/api/client';
+
+vi.mock('@/services/api/client', () => ({
+  apiClient: {
+    createSSEToken: vi.fn(),
+  },
+}));
+
+describe('useSSEToken', () => {
+  const mockCreateSSEToken = vi.mocked(apiClient.createSSEToken);
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renews the token before the ttl expires', async () => {
+    mockCreateSSEToken
+      .mockResolvedValueOnce({
+        token: 'sse_first',
+        expires_at: '2025-12-31T23:59:59Z',
+        scope: 'queue',
+        permissions: ['read'],
+        ttl: 61,
+      })
+      .mockResolvedValueOnce({
+        token: 'sse_second',
+        expires_at: '2025-12-31T23:59:59Z',
+        scope: 'queue',
+        permissions: ['read'],
+        ttl: 61,
+      });
+
+    const { result } = renderHook(() => useSSEToken('queue', 600, 'Failed to fetch SSE token:'));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.token).toBe('sse_first');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(mockCreateSSEToken).toHaveBeenCalledTimes(2);
+    expect(result.current.token).toBe('sse_second');
+  });
+});

--- a/packages/hermes-app/src/hooks/useSSEToken.ts
+++ b/packages/hermes-app/src/hooks/useSSEToken.ts
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import { apiClient } from '@/services/api/client';
+
+const TOKEN_RENEWAL_BUFFER_MS = 60_000;
+const MIN_RENEWAL_DELAY_MS = 1_000;
+
+interface SSETokenState {
+  token: string | null;
+  error: Error | null;
+}
+
+interface SSETokenResponse {
+  token: string;
+  expires_at?: string;
+  expiresAt?: string;
+  ttl?: number;
+}
+
+function getRenewalDelay(response: SSETokenResponse, requestedTtl: number): number {
+  const ttlDelay = (response.ttl ?? requestedTtl) * 1000 - TOKEN_RENEWAL_BUFFER_MS;
+  const expiry = response.expires_at ?? response.expiresAt;
+
+  if (expiry) {
+    const expiryDelay = Date.parse(expiry) - Date.now() - TOKEN_RENEWAL_BUFFER_MS;
+    if (Number.isFinite(expiryDelay) && expiryDelay > 0) {
+      return Math.max(Math.min(expiryDelay, ttlDelay), MIN_RENEWAL_DELAY_MS);
+    }
+  }
+
+  return Math.max(ttlDelay, MIN_RENEWAL_DELAY_MS);
+}
+
+export function useSSEToken(scope: string, ttl: number, errorMessage: string): SSETokenState {
+  const [token, setToken] = useState<string | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    let renewalTimeout: ReturnType<typeof setTimeout> | null = null;
+
+    async function fetchSSEToken() {
+      try {
+        const response = await apiClient.createSSEToken({ scope, ttl });
+
+        if (!mounted) return;
+
+        setToken(response.token);
+        setError(null);
+
+        renewalTimeout = setTimeout(fetchSSEToken, getRenewalDelay(response, ttl));
+      } catch (err) {
+        console.error(errorMessage, err);
+        if (mounted) {
+          setError(err instanceof Error ? err : new Error('Failed to fetch SSE token'));
+        }
+      }
+    }
+
+    fetchSSEToken();
+
+    return () => {
+      mounted = false;
+      if (renewalTimeout) {
+        clearTimeout(renewalTimeout);
+      }
+    };
+  }, [scope, ttl, errorMessage]);
+
+  return { token, error };
+}

--- a/packages/hermes-app/src/hooks/useStatsSSE.ts
+++ b/packages/hermes-app/src/hooks/useStatsSSE.ts
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSSE } from './useSSE';
-import { apiClient } from '@/services/api/client';
+import { useSSEToken } from './useSSEToken';
 import { getApiBaseUrl } from '@/lib/config';
 
 export interface StatsUpdate {
@@ -34,38 +34,11 @@ export interface StatsUpdate {
  */
 export function useStatsSSE() {
   const queryClient = useQueryClient();
-  const [sseToken, setSSEToken] = useState<string | null>(null);
-  const [tokenError, setTokenError] = useState<Error | null>(null);
-
-  // Fetch SSE token on mount
-  useEffect(() => {
-    let mounted = true;
-
-    async function fetchSSEToken() {
-      try {
-        const response = await apiClient.createSSEToken({
-          scope: 'stats',
-          ttl: 600, // 10 minutes
-        });
-
-        if (mounted) {
-          setSSEToken(response.token);
-          setTokenError(null);
-        }
-      } catch (err) {
-        console.error('Failed to fetch SSE token for stats:', err);
-        if (mounted) {
-          setTokenError(err instanceof Error ? err : new Error('Failed to fetch SSE token'));
-        }
-      }
-    }
-
-    fetchSSEToken();
-
-    return () => {
-      mounted = false;
-    };
-  }, []); // Only fetch once on mount
+  const { token: sseToken, error: tokenError } = useSSEToken(
+    'stats',
+    600,
+    'Failed to fetch SSE token for stats:'
+  );
 
   // Build SSE URL with ephemeral token
   const sseUrl = useMemo(() => {


### PR DESCRIPTION
## Summary
- add a reusable SSE token hook that renews scoped tokens before ttl expiry
- reconnect download, queue, and stats SSE streams with fresh token URLs
- cover token renewal with a focused hook test

## Validation
- pnpm --filter hermes-app test src/hooks/useSSEToken.test.ts src/hooks/useDownloadProgressSSE.test.tsx src/hooks/useQueueUpdatesSSE.test.tsx src/hooks/useStatsSSE.test.tsx
- pnpm --filter hermes-app type-check
- pnpm --filter hermes-app lint