### PR TITLE
[codex] Remove frontend token logging

### DIFF
--- a/packages/hermes-app/src/services/auth.ts
+++ b/packages/hermes-app/src/services/auth.ts
@@ -9,7 +9,6 @@ class AuthService {
 
   constructor() {
     this.baseURL = getApiBaseUrl()
-    console.log(`[AuthService] Using API base URL: ${this.baseURL}`)
   }
 
   public getBaseURL(): string {
@@ -115,16 +114,12 @@ class AuthService {
   async getCurrentUser(): Promise<User> {
     try {
       const headers = await this.getAuthHeaders()
-      console.log('[AuthService] getCurrentUser - headers:', headers)
-      console.log('[AuthService] getCurrentUser - URL:', `${this.baseURL}/auth/me`)
       
       const response = await fetch(`${this.baseURL}/auth/me`, {
         method: 'GET',
         headers,
       })
 
-      console.log('[AuthService] getCurrentUser - response status:', response.status)
-      
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({ detail: 'Failed to get user data' }))
         console.error('[AuthService] getCurrentUser - error response:', errorData)
@@ -132,7 +127,6 @@ class AuthService {
       }
 
       const userData = await response.json()
-      console.log('[AuthService] getCurrentUser - success:', userData.username)
       return userData
     } catch (error) {
       console.error('[AuthService] getCurrentUser failed:', error)
@@ -142,10 +136,6 @@ class AuthService {
 
   private async getAuthHeaders(): Promise<Record<string, string>> {
     const token = TokenStorage.getAccessToken()
-    console.log('[AuthService] getAuthHeaders - token exists:', !!token, 'token length:', token?.length || 0)
-    if (token) {
-      console.log('[AuthService] getAuthHeaders - token preview:', token.substring(0, 20) + '...')
-    }
     
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',

--- a/packages/hermes-app/src/utils/tokenStorage.ts
+++ b/packages/hermes-app/src/utils/tokenStorage.ts
@@ -22,7 +22,6 @@ export class TokenStorage {
         localStorage.setItem(this.TOKEN_EXPIRY_KEY, expiryTime.toString())
       }
 
-      console.log('[TokenStorage] Access token stored securely')
     } catch (error) {
       console.warn('[TokenStorage] SessionStorage failed, falling back to localStorage:', error)
       try {
@@ -42,10 +41,7 @@ export class TokenStorage {
       const token = sessionStorage.getItem(this.ACCESS_TOKEN_KEY) ||
                    localStorage.getItem(this.ACCESS_TOKEN_KEY)
 
-      console.log('[TokenStorage] getAccessToken - token found:', !!token, 'source:', token ? (sessionStorage.getItem(this.ACCESS_TOKEN_KEY) ? 'sessionStorage' : 'localStorage') : 'none')
-
       if (!token) {
-        console.log('[TokenStorage] getAccessToken - no token found')
         return null
       }
 
@@ -53,15 +49,12 @@ export class TokenStorage {
       const expiryTime = localStorage.getItem(this.TOKEN_EXPIRY_KEY)
       if (expiryTime) {
         const isExpired = Date.now() > parseInt(expiryTime)
-        console.log('[TokenStorage] getAccessToken - expiry check:', { expiryTime: new Date(parseInt(expiryTime)), isExpired })
         if (isExpired) {
           this.clearTokens()
-          console.log('[TokenStorage] Token expired, cleared automatically')
           return null
         }
       }
 
-      console.log('[TokenStorage] getAccessToken - returning valid token, length:', token.length, 'preview:', token.substring(0, 20) + '...')
       return token
     } catch (error) {
       console.warn('[TokenStorage] Error retrieving token:', error)
@@ -80,7 +73,6 @@ export class TokenStorage {
     try {
       // Use localStorage for refresh tokens (longer persistence)
       localStorage.setItem(this.REFRESH_TOKEN_KEY, token)
-      console.log('[TokenStorage] Refresh token stored')
     } catch (error) {
       console.warn('[TokenStorage] Failed to store refresh token:', error)
     }
@@ -115,8 +107,6 @@ export class TokenStorage {
     } catch (error) {
       console.warn('[TokenStorage] Failed to clear localStorage:', error)
     }
-
-    console.log('[TokenStorage] All tokens cleared')
   }
 
   /**


### PR DESCRIPTION
## Summary
- remove auth header dumps and token preview logs from frontend auth code
- keep existing warning/error handling for storage and request failures

## Validation
- pnpm --filter hermes-app test src/utils/__tests__/tokenStorage.test.ts src/services/__tests__/auth.test.ts