### PR TITLE
[codex] Wire queue cancel actions

### DIFF
--- a/packages/hermes-app/src/components/queue/BulkOperations.tsx
+++ b/packages/hermes-app/src/components/queue/BulkOperations.tsx
@@ -45,10 +45,14 @@ export function BulkOperations({
     })
   }
 
+  const cancellableCount = selectedItems.filter(item =>
+    item.status === 'queued' || item.status === 'downloading' || item.status === 'processing'
+  ).length
+
   const handleBulkCancel = () => {
     showConfirmation({
       title: 'Cancel Multiple Downloads',
-      description: `Are you sure you want to cancel ${selectedCount} selected downloads?`,
+      description: `Are you sure you want to cancel ${cancellableCount} selected ${cancellableCount === 1 ? 'download' : 'downloads'}?`,
       confirmText: 'Cancel Downloads',
       cancelText: 'Keep Downloads',
       variant: 'destructive',
@@ -59,10 +63,6 @@ export function BulkOperations({
   if (selectedCount === 0) {
     return null
   }
-
-  const hasCancellableItems = selectedItems.some(item =>
-    item.status === 'queued' || item.status === 'downloading' || item.status === 'processing'
-  )
 
   return (
     <>
@@ -100,7 +100,7 @@ export function BulkOperations({
             </div>
 
             <div className="flex items-center gap-2">
-              {hasCancellableItems && (
+              {cancellableCount > 0 && (
                 <Button
                   variant="outline"
                   size="sm"
@@ -109,7 +109,7 @@ export function BulkOperations({
                   className="text-orange-600 hover:text-orange-700"
                 >
                   <X className="h-4 w-4 mr-1" />
-                  Cancel ({selectedCount})
+                  Cancel ({cancellableCount})
                 </Button>
               )}
 

--- a/packages/hermes-app/src/components/queue/QueueCard.tsx
+++ b/packages/hermes-app/src/components/queue/QueueCard.tsx
@@ -10,7 +10,7 @@ import {
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiClient } from '@/services/api/client'
 import { toast } from 'sonner'
-import { useDownloadFile } from '@/hooks/useDownloadActions'
+import { useCancelDownload, useDownloadFile } from '@/hooks/useDownloadActions'
 import { StatusBadge } from '@/components/ui/status-badge'
 import { DownloadProgress } from '@/components/ui/download-progress'
 import { DownloadProgressTracker } from '@/components/download/DownloadProgressTracker'
@@ -38,6 +38,7 @@ export function QueueCard({ download, isSelectable = false, isSelected = false, 
   const { isOpen, title, description, confirmText, cancelText, variant, showConfirmation, hideConfirmation, confirm } = useConfirmation()
   const [isDismissing, setIsDismissing] = useState(false)
   const downloadFile = useDownloadFile()
+  const cancelDownload = useCancelDownload()
 
   // Delete mutation
   const deleteMutation = useMutation({
@@ -255,15 +256,20 @@ export function QueueCard({ download, isSelectable = false, isSelected = false, 
             </Button>
           )}
 
-          {(download.status === 'downloading' || download.status === 'queued') && (
+          {(download.status === 'downloading' || download.status === 'processing' || download.status === 'queued') && (
             <Button
               variant="ghost"
               size="icon"
               className="h-8 w-8 text-muted-foreground hover:text-destructive"
               title="Cancel Download"
-              onClick={() => toast.info('Cancel functionality coming soon!')}
+              onClick={() => cancelDownload.mutate(download.downloadId)}
+              disabled={cancelDownload.isPending}
             >
-              <X className="h-4 w-4" />
+              {cancelDownload.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <X className="h-4 w-4" />
+              )}
             </Button>
           )}
         </div>
@@ -282,4 +288,3 @@ export function QueueCard({ download, isSelectable = false, isSelected = false, 
     </Blur>
   )
 }
-

--- a/packages/hermes-app/src/components/queue/QueueTabContent.tsx
+++ b/packages/hermes-app/src/components/queue/QueueTabContent.tsx
@@ -81,7 +81,14 @@ export function QueueTabContent({
             status: item.status
           })) || []
         )}
-        onBulkCancel={() => {}} // TODO: Implement bulk cancel
+        onBulkCancel={() => bulkOperations.bulkCancel(
+          queueData?.items?.map((item: components["schemas"]["DownloadStatus"]) => ({
+            id: item.downloadId,
+            title: String(item.result?.title || item.downloadId),
+            filePath: item.currentFilename || undefined,
+            status: item.status
+          })) || []
+        )}
         isProcessing={bulkOperations.isProcessing}
       />
 

--- a/packages/hermes-app/src/components/queue/__tests__/QueueCard.test.tsx
+++ b/packages/hermes-app/src/components/queue/__tests__/QueueCard.test.tsx
@@ -12,6 +12,8 @@ import { QueueCard } from '../QueueCard'
 import type { DownloadStatus } from '@/types'
 import { toast } from 'sonner'
 
+const mockCancelDownloadMutate = vi.hoisted(() => vi.fn())
+
 // Mock dependencies
 vi.mock('sonner', () => ({
   toast: {
@@ -24,6 +26,10 @@ vi.mock('sonner', () => ({
 vi.mock('@/hooks/useDownloadActions', () => ({
   useDownloadFile: () => ({
     mutate: vi.fn(),
+    isPending: false,
+  }),
+  useCancelDownload: () => ({
+    mutate: mockCancelDownloadMutate,
     isPending: false,
   }),
 }))
@@ -451,7 +457,7 @@ describe('QueueCard', () => {
       expect(toast.info).toHaveBeenCalledWith('Retry functionality coming soon!')
     })
 
-    it('shows toast when cancel button clicked', async () => {
+    it('cancels download when cancel button clicked', async () => {
       const user = userEvent.setup()
       const downloadingDownload = { ...mockDownload, status: 'downloading' as const }
 
@@ -460,7 +466,7 @@ describe('QueueCard', () => {
       const cancelButton = screen.getByTitle('Cancel Download')
       await user.click(cancelButton)
 
-      expect(toast.info).toHaveBeenCalledWith('Cancel functionality coming soon!')
+      expect(mockCancelDownloadMutate).toHaveBeenCalledWith('test-123')
     })
   })
 

--- a/packages/hermes-app/src/hooks/useBulkOperations.ts
+++ b/packages/hermes-app/src/hooks/useBulkOperations.ts
@@ -1,5 +1,7 @@
 import { useState, useCallback } from 'react'
 import { useDeleteFiles } from './useDownloadActions'
+import { apiClient } from '@/services/api/client'
+import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 interface BulkOperationItem {
@@ -18,6 +20,7 @@ export function useBulkOperations(options: UseBulkOperationsOptions = {}) {
   const { onSuccess, onError } = options
   const [selectedItems, setSelectedItems] = useState<Set<string>>(new Set())
   const [isProcessing, setIsProcessing] = useState(false)
+  const queryClient = useQueryClient()
 
   const deleteMutation = useDeleteFiles()
 
@@ -98,6 +101,41 @@ export function useBulkOperations(options: UseBulkOperationsOptions = {}) {
     toast.info('Bulk retry coming soon!')
   }, [selectedItems])
 
+  const bulkCancel = useCallback(async (items: BulkOperationItem[]) => {
+    const selectedItemIds = Array.from(selectedItems)
+    if (selectedItemIds.length === 0) {
+      toast.error('No items selected')
+      return
+    }
+
+    const cancellableItems = items.filter(item =>
+      selectedItemIds.includes(item.id) &&
+      (item.status === 'queued' || item.status === 'downloading' || item.status === 'processing')
+    )
+
+    if (cancellableItems.length === 0) {
+      toast.error('No cancellable downloads found in selection')
+      return
+    }
+
+    setIsProcessing(true)
+
+    try {
+      await Promise.all(cancellableItems.map(item => apiClient.cancelDownload(item.id)))
+      toast.success(`Cancelled ${cancellableItems.length} download${cancellableItems.length !== 1 ? 's' : ''}`)
+      deselectAll()
+      queryClient.invalidateQueries({ queryKey: ['queue'], exact: false })
+      queryClient.invalidateQueries({ queryKey: ['queueStats'], exact: false })
+      queryClient.invalidateQueries({ queryKey: ['recentDownloadsQueue'], exact: false })
+      onSuccess?.()
+    } catch (error) {
+      toast.error(`Failed to cancel downloads: ${error instanceof Error ? error.message : 'Unknown error'}`)
+      onError?.(error as Error)
+    } finally {
+      setIsProcessing(false)
+    }
+  }, [selectedItems, deselectAll, queryClient, onSuccess, onError])
+
   const getSelectedItems = useCallback((items: BulkOperationItem[]) => {
     const selectedIds = Array.from(selectedItems)
     return items.filter(item => selectedIds.includes(item.id))
@@ -117,6 +155,7 @@ export function useBulkOperations(options: UseBulkOperationsOptions = {}) {
 
     // Bulk operations
     bulkDelete,
+    bulkCancel,
     bulkRetry,
 
     // Utilities


### PR DESCRIPTION
## Summary
- connect queue card cancel buttons to the existing cancel download mutation
- add bulk cancel handling for selected queued, downloading, and processing items
- update queue card tests for the real cancel action

## Validation
- pnpm --filter hermes-app test src/components/queue/__tests__/QueueCard.test.tsx
- pnpm --filter hermes-app type-check
- pnpm --filter hermes-app lint