### PR TITLE
[codex] Persist refreshed API client tokens

### DIFF
--- a/packages/hermes-app/src/services/__tests__/apiClient.test.ts
+++ b/packages/hermes-app/src/services/__tests__/apiClient.test.ts
@@ -138,10 +138,13 @@ describe('ApiClient - API Key Methods', () => {
         },
       ]
 
-      vi.spyOn(TokenStorage, 'getAccessToken').mockReturnValue('fresh-token')
+      const getAccessTokenSpy = vi
+        .spyOn(TokenStorage, 'getAccessToken')
+        .mockReturnValueOnce('expired-token')
+        .mockReturnValueOnce('fresh-token')
       vi.spyOn(TokenStorage, 'getRefreshToken').mockReturnValue('refresh-token')
-      vi.spyOn(TokenStorage, 'setAccessToken').mockImplementation(() => {})
-      vi.spyOn(TokenStorage, 'setRefreshToken').mockImplementation(() => {})
+      const setAccessTokenSpy = vi.spyOn(TokenStorage, 'setAccessToken').mockImplementation(() => {})
+      const setRefreshTokenSpy = vi.spyOn(TokenStorage, 'setRefreshToken').mockImplementation(() => {})
 
       mockFetch
         .mockResolvedValueOnce({
@@ -169,6 +172,9 @@ describe('ApiClient - API Key Methods', () => {
       })
 
       expect(result).toEqual(mockApiKeys)
+      expect(setAccessTokenSpy).toHaveBeenCalledWith('fresh-token', 15)
+      expect(setRefreshTokenSpy).toHaveBeenCalledWith('fresh-refresh-token')
+      expect(getAccessTokenSpy).toHaveBeenCalledTimes(2)
       expect(mockFetch).toHaveBeenNthCalledWith(
         3,
         '/api/v1/auth/api-keys',

--- a/packages/hermes-app/src/services/api/client.ts
+++ b/packages/hermes-app/src/services/api/client.ts
@@ -387,7 +387,11 @@ class ApiClient {
       throw new Error(`Token refresh failed: ${errorData.detail || response.statusText}`)
     }
 
-    return response.json()
+    const tokenResponse = await response.json()
+    TokenStorage.setAccessToken(tokenResponse.accessToken, 15)
+    TokenStorage.setRefreshToken(tokenResponse.refreshToken)
+
+    return tokenResponse
   }
 
   // Delete downloaded files


### PR DESCRIPTION
## Summary
- Persist refreshed access and refresh tokens in the shared API client refresh path
- Strengthen the API client retry test so it verifies token storage before retry headers are rebuilt

## Root cause
The private ApiClient refresh method returned the refresh response but did not write the new tokens to TokenStorage, so 401 retries could reuse stale or missing credentials and redirect to login.

## Validation
- pnpm --dir packages/hermes-app exec vitest run src/services/__tests__/apiClient.test.ts
- pnpm --dir packages/hermes-app test
- pnpm --dir packages/hermes-app type-check