### PR TITLE
[codex] Unify auth principal resolution

### DIFF
--- a/packages/hermes-api/app/api/dependencies.py
+++ b/packages/hermes-api/app/api/dependencies.py
@@ -2,7 +2,6 @@
 FastAPI dependencies for authentication and authorization.
 """
 
-from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import Depends, HTTPException, status
@@ -10,8 +9,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.logging import get_logger
-from app.core.security import verify_token
-from app.db.repositories import TokenBlacklistRepository, UserRepository
+from app.core.security import get_current_principal
 from app.db.session import get_database_session
 
 logger = get_logger(__name__)
@@ -24,91 +22,8 @@ async def get_current_user_from_token(
 ) -> dict:
     """Extract and validate JWT token, return current user."""
     try:
-        logger.info("====== get_current_user_from_token called ======")
-        scheme = credentials.scheme if credentials else None
-        token_length = len(credentials.credentials) if credentials else 0
-        logger.info(
-            f"Credentials received: scheme={scheme}, token_length={token_length}"
-        )
-
-        # Verify JWT token
-        payload = verify_token(credentials.credentials)
-        logger.info(
-            f"Token verification result: {payload is not None}",
-            payload_keys=list(payload.keys()) if payload else None,
-        )
-
-        if not payload:
-            logger.warning("Token verification returned None")
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid authentication credentials",
-                headers={"WWW-Authenticate": "Bearer"},
-            )
-
-        username: str = payload.get("sub")
-        user_id: str = payload.get("user_id")
-        token_id: str = payload.get("jti")  # JWT ID for blacklist checking
-        token_info = f"username={username}, user_id={user_id}, jti={token_id}"
-        logger.info(f"Extracted from token: {token_info}")
-
-        if not username or not user_id:
-            logger.warning("Missing username or user_id in token payload")
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload"
-            )
-
-        # Check if token is blacklisted
-        token_blacklist_repo = TokenBlacklistRepository(db_session)
-        if token_id:
-            is_blacklisted = await token_blacklist_repo.is_blacklisted(token_id)
-            if is_blacklisted:
-                logger.warning(f"Token is blacklisted: {token_id}")
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Token has been revoked",
-                )
-
-        # Verify user still exists and is active
-        user_repo = UserRepository(db_session)
-        user = await user_repo.get_by_id(user_id)
-        logger.info(f"User lookup result: found={user is not None}")
-
-        if not user:
-            logger.warning(f"User not found for user_id: {user_id}")
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found"
-            )
-
-        if not user.is_active:
-            logger.warning(f"User account disabled: {user_id}")
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="User account is disabled",
-            )
-
-        # Check token expiration
-        exp = payload.get("exp")
-        if exp and datetime.now(timezone.utc) > datetime.fromtimestamp(
-            exp, timezone.utc
-        ):
-            logger.warning(f"Token expired: exp={exp}")
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED, detail="Token has expired"
-            )
-
-        logger.info(f"Successfully authenticated user: {username}")
-        return {
-            "id": user.id,
-            "username": user.username,
-            "email": user.email,
-            "avatar": user.avatar,
-            "is_admin": user.is_admin,
-            "preferences": user.preferences,
-            "created_at": user.created_at.isoformat() if user.created_at else None,
-            "last_login": user.last_login.isoformat() if user.last_login else None,
-            "token_id": token_id,  # Include token ID for logout
-        }
+        principal = await get_current_principal(credentials, db_session)
+        return principal.as_user_dict()
 
     except HTTPException:
         raise

--- a/packages/hermes-api/app/api/v1/endpoints/downloads.py
+++ b/packages/hermes-api/app/api/v1/endpoints/downloads.py
@@ -2,11 +2,11 @@
 Download management endpoints.
 """
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.logging import get_logger
-from app.core.security import get_current_api_key, validate_database_api_key
+from app.core.security import get_current_api_key
 from app.db.repositories import DownloadRepository
 from app.db.session import get_database_session
 from app.models.pydantic.download import (
@@ -86,18 +86,6 @@ async def start_download(
         DownloadResponse: Download ID and initial status
     """
     try:
-        # Validate database API keys
-        if api_key.startswith("db_api_key:"):
-            validated_key = await validate_database_api_key(
-                api_key.replace("db_api_key:", ""), db_session
-            )
-            if not validated_key:
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Invalid or inactive API key",
-                )
-            api_key = validated_key
-
         logger.info(
             "Starting download",
             url=download_request.url[:50] + "...",

--- a/packages/hermes-api/app/api/v1/endpoints/events.py
+++ b/packages/hermes-api/app/api/v1/endpoints/events.py
@@ -11,7 +11,8 @@ from sse_starlette.sse import EventSourceResponse
 from app.core.config import settings
 from app.core.logging import get_logger
 from app.core.security import (
-    get_current_api_key,
+    AuthPrincipal,
+    get_current_principal,
     get_current_sse_token,
     validate_sse_token,
 )
@@ -309,7 +310,7 @@ async def stats_events(
 @router.post("/token", response_model=SSETokenResponse)
 async def create_sse_token(
     request: CreateSSETokenRequest = Body(...),
-    api_key: str = Depends(get_current_api_key),
+    principal: AuthPrincipal = Depends(get_current_principal),
     db_session: AsyncSession = Depends(get_database_session),
 ):
     """
@@ -360,17 +361,7 @@ async def create_sse_token(
     - `queue` - Queue updates
     - `system` - System notifications
     """
-    # Extract user_id from api_key
-    user_id = None
-    if api_key.startswith("user:"):
-        user_id = api_key.split(":", 1)[1]
-    elif api_key.startswith("db_api_key:"):
-        # For database API keys, we'd need to look up the user
-        # For now, use the API key as identifier
-        user_id = api_key
-    else:
-        # For configured API keys, use the key as identifier
-        user_id = f"api_key:{api_key[:8]}"
+    user_id = principal.user_id or principal.subject
 
     # Validate scope format
     scope = request.scope

--- a/packages/hermes-api/app/core/security.py
+++ b/packages/hermes-api/app/core/security.py
@@ -4,8 +4,9 @@ Security utilities for API authentication and authorization.
 
 import hashlib
 import secrets
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 import bcrypt
 import jwt
@@ -15,7 +16,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.logging import get_logger
-from app.db.repositories import ApiKeyRepository
+from app.db.repositories import (
+    ApiKeyRepository,
+    TokenBlacklistRepository,
+    UserRepository,
+)
+from app.db.session import get_database_session
 
 logger = get_logger(__name__)
 
@@ -24,6 +30,56 @@ security = HTTPBearer()
 
 # Optional HTTP Bearer for SSE endpoints (doesn't raise error if missing)
 optional_security = HTTPBearer(auto_error=False)
+
+
+@dataclass(frozen=True)
+class AuthPrincipal:
+    """Authenticated caller resolved from a JWT, configured API key, or DB API key."""
+
+    kind: Literal["user", "api_key"]
+    subject: str
+    user_id: Optional[str] = None
+    username: Optional[str] = None
+    email: Optional[str] = None
+    avatar: Optional[str] = None
+    is_admin: bool = False
+    preferences: Optional[dict] = None
+    created_at: Optional[str] = None
+    last_login: Optional[str] = None
+    token_id: Optional[str] = None
+    api_key_id: Optional[str] = None
+    api_key_name: Optional[str] = None
+    permissions: list[str] = field(default_factory=list)
+
+    @property
+    def legacy_identifier(self) -> str:
+        """Stable string for routes that only need to know auth succeeded."""
+        if self.kind == "user" and self.user_id:
+            return f"user:{self.user_id}"
+        if self.api_key_id:
+            return f"db_api_key:{self.api_key_id}"
+        return self.subject
+
+    def as_user_dict(self) -> dict:
+        """Return the historical user dict shape used by auth/admin endpoints."""
+        if self.kind != "user" or not self.user_id:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="User authentication required",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+        return {
+            "id": self.user_id,
+            "username": self.username,
+            "email": self.email,
+            "avatar": self.avatar,
+            "is_admin": self.is_admin,
+            "preferences": self.preferences,
+            "created_at": self.created_at,
+            "last_login": self.last_login,
+            "token_id": self.token_id,
+        }
 
 
 def create_api_key() -> str:
@@ -129,45 +185,161 @@ def verify_token(token: str) -> Optional[dict]:
         return None
 
 
-async def validate_database_api_key(
-    api_key: str, db_session: AsyncSession
-) -> Optional[str]:
-    """Validate a database API key and return the API key if valid."""
-    try:
-        api_key_repo = ApiKeyRepository(db_session)
-        db_api_key = await api_key_repo.get_by_key_hash(hash_api_key(api_key))
+async def _principal_from_jwt(
+    token: str, db_session: AsyncSession
+) -> Optional[AuthPrincipal]:
+    """Validate a JWT and resolve it to an active user principal."""
+    payload = verify_token(token)
+    if not payload:
+        return None
 
-        if db_api_key:
-            # Check if API key is active
-            if not db_api_key.is_active:
-                logger.warning(f"Inactive API key used: {db_api_key.id}")
-                return None
+    username: str = payload.get("sub")
+    user_id: str = payload.get("user_id")
+    token_id: str = payload.get("jti")
 
-            # Check if API key has expired
-            if (
-                db_api_key.expires_at
-                and datetime.now(timezone.utc) > db_api_key.expires_at
-            ):
-                logger.warning(f"Expired API key used: {db_api_key.id}")
-                return None
+    if not username or not user_id:
+        logger.warning("Missing username or user_id in token payload")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token payload",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
-            # Update last used timestamp
-            await api_key_repo.update_last_used(db_api_key.id)
-
-            logger.info(
-                f"Valid database API key used: {db_api_key.id} for user {db_api_key.user_id}"
+    if token_id:
+        token_blacklist_repo = TokenBlacklistRepository(db_session)
+        if await token_blacklist_repo.is_blacklisted(token_id):
+            logger.warning(f"Token is blacklisted: {token_id}")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Token has been revoked",
+                headers={"WWW-Authenticate": "Bearer"},
             )
-            return api_key
 
-    except Exception as e:
-        logger.warning(f"Database API key validation error: {str(e)}")
+    user_repo = UserRepository(db_session)
+    user = await user_repo.get_by_id(user_id)
+    if not user:
+        logger.warning(f"User not found for user_id: {user_id}")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
-    return None
+    if not user.is_active:
+        logger.warning(f"User account disabled: {user_id}")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User account is disabled",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    return AuthPrincipal(
+        kind="user",
+        subject=f"user:{user.id}",
+        user_id=user.id,
+        username=user.username,
+        email=user.email,
+        avatar=user.avatar,
+        is_admin=user.is_admin,
+        preferences=user.preferences,
+        created_at=user.created_at.isoformat() if user.created_at else None,
+        last_login=user.last_login.isoformat() if user.last_login else None,
+        token_id=token_id,
+    )
+
+
+async def _principal_from_api_key(
+    api_key: str, db_session: AsyncSession
+) -> Optional[AuthPrincipal]:
+    """Validate configured and database-backed API keys."""
+    for configured_key in settings.api_keys:
+        if verify_api_key(api_key, hash_api_key(configured_key)):
+            return AuthPrincipal(
+                kind="api_key",
+                subject=f"configured_api_key:{hash_api_key(configured_key)[:12]}",
+                permissions=["admin"],
+            )
+
+    api_key_repo = ApiKeyRepository(db_session)
+    db_api_key = await api_key_repo.get_by_key_hash(hash_api_key(api_key))
+    if not db_api_key:
+        return None
+
+    if not db_api_key.is_active:
+        logger.warning(f"Inactive API key used: {db_api_key.id}")
+        return None
+
+    if db_api_key.expires_at and datetime.now(timezone.utc) > db_api_key.expires_at:
+        logger.warning(f"Expired API key used: {db_api_key.id}")
+        return None
+
+    await api_key_repo.update_last_used(db_api_key.id)
+
+    return AuthPrincipal(
+        kind="api_key",
+        subject=f"db_api_key:{db_api_key.id}",
+        user_id=db_api_key.user_id,
+        api_key_id=db_api_key.id,
+        api_key_name=db_api_key.name,
+        permissions=db_api_key.permissions or [],
+    )
+
+
+async def get_current_principal(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+    db_session: AsyncSession = Depends(get_database_session),
+) -> AuthPrincipal:
+    """Resolve the current authenticated caller from a bearer JWT or API key."""
+    if credentials is None:
+        logger.warning("No authorization credentials provided")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authorization required",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    token = credentials.credentials
+
+    if credentials.scheme.lower() == "bearer":
+        jwt_principal = await _principal_from_jwt(token, db_session)
+        if jwt_principal:
+            return jwt_principal
+
+    api_key_principal = await _principal_from_api_key(token, db_session)
+    if api_key_principal:
+        return api_key_principal
+
+    logger.warning(
+        "Invalid bearer credential provided", key_hash=hash_api_key(token)[:8]
+    )
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid authentication credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+async def get_current_principal_optional(
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(optional_security),
+    token: Optional[str] = Query(None),
+    db_session: AsyncSession = Depends(get_database_session),
+) -> Optional[AuthPrincipal]:
+    """Resolve an optional authenticated caller from a header or query token."""
+    auth_token = credentials.credentials if credentials else token
+    if not auth_token:
+        return None
+
+    jwt_principal = await _principal_from_jwt(auth_token, db_session)
+    if jwt_principal:
+        return jwt_principal
+
+    return await _principal_from_api_key(auth_token, db_session)
 
 
 async def get_current_api_key_optional(
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(optional_security),
     token: Optional[str] = Query(None),
+    db_session: AsyncSession = Depends(get_database_session),
 ) -> Optional[str]:
     """
     Extract and validate API key from Authorization header or query param.
@@ -182,100 +354,17 @@ async def get_current_api_key_optional(
     Returns:
         Validated API key/user marker or None if no auth provided
     """
-    # Try Authorization header first
-    auth_token = None
-    if credentials:
-        auth_token = credentials.credentials
-    # Fall back to query param (for EventSource SSE connections)
-    elif token:
-        auth_token = token
-    else:
-        return None
-
-    # Validate token (JWT or API key)
-    payload = verify_token(auth_token)
-    if payload:
-        user_id = payload.get("user_id")
-        if user_id:
-            logger.info(f"Accepting user token for user_id: {user_id}")
-            return f"user:{user_id}"
-
-        api_key = payload.get("api_key")
-        if api_key:
-            return api_key
-
-    # Check configured API keys
-    for configured_key in settings.api_keys:
-        if verify_api_key(auth_token, hash_api_key(configured_key)):
-            return configured_key
-
-    # Check database API keys
-    if len(auth_token) >= 32:
-        logger.info(f"Database API key provided, length: {len(auth_token)}")
-        return f"db_api_key:{auth_token}"
-
-    return None
+    principal = await get_current_principal_optional(credentials, token, db_session)
+    return principal.legacy_identifier if principal else None
 
 
 async def get_current_api_key(
     credentials: HTTPAuthorizationCredentials = Depends(security),
+    db_session: AsyncSession = Depends(get_database_session),
 ) -> str:
     """Extract and validate API key from Authorization header."""
-    if credentials is None:
-        logger.warning("No authorization credentials provided")
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Authorization required",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    # Check if it's a Bearer token (JWT)
-    if credentials.scheme.lower() == "bearer":
-        payload = verify_token(credentials.credentials)
-        logger.info(
-            f"JWT verification result: {payload is not None}",
-            payload_keys=list(payload.keys()) if payload else None,
-        )
-        if payload:
-            # If it's a valid JWT (user token), allow access
-            user_id = payload.get("user_id")
-            logger.info(f"User ID from payload: {user_id}")
-            if user_id:
-                # Valid user token, return a special marker
-                logger.info(f"Accepting user token for user_id: {user_id}")
-                return f"user:{user_id}"
-
-            # Check for API key in JWT
-            api_key = payload.get("api_key")
-            if api_key:
-                return api_key
-
-    # Otherwise treat as API key directly
-    api_key = credentials.credentials
-
-    # First, validate against configured API keys (legacy support)
-    for configured_key in settings.api_keys:
-        if verify_api_key(api_key, hash_api_key(configured_key)):
-            return configured_key
-
-    # Then validate against database-stored API keys
-    # Note: Database validation will be handled by the endpoint dependencies
-    # since get_current_api_key cannot access the database session directly
-    try:
-        # Basic format validation
-        if len(api_key) >= 32:  # Basic validation that it looks like an API key
-            logger.info(f"Database API key provided, length: {len(api_key)}")
-            # Return a special marker that endpoints will validate against the database
-            return f"db_api_key:{api_key}"
-    except Exception as e:
-        logger.warning(f"API key validation error: {str(e)}")
-
-    logger.warning("Invalid API key provided", key_hash=hash_api_key(api_key)[:8])
-    raise HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Invalid API key",
-        headers={"WWW-Authenticate": "Bearer"},
-    )
+    principal = await get_current_principal(credentials, db_session)
+    return principal.legacy_identifier
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:

--- a/packages/hermes-api/tests/conftest.py
+++ b/packages/hermes-api/tests/conftest.py
@@ -65,14 +65,26 @@ async def db_session(setup_test_database) -> AsyncGenerator[AsyncSession, None]:
 @pytest_asyncio.fixture
 async def client(setup_test_database) -> AsyncGenerator[AsyncClient, None]:
     """Create an async HTTP client for testing with auth mocked."""
-    from app.core.security import get_current_api_key
+    from app.core.security import (
+        AuthPrincipal,
+        get_current_api_key,
+        get_current_principal,
+    )
     from app.main import app
 
     # Override authentication dependency for testing
     async def mock_get_api_key():
         return "test-api-key"
 
+    async def mock_get_principal():
+        return AuthPrincipal(
+            kind="api_key",
+            subject="test-api-key",
+            permissions=["admin"],
+        )
+
     app.dependency_overrides[get_current_api_key] = mock_get_api_key
+    app.dependency_overrides[get_current_principal] = mock_get_principal
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://testserver") as client:

--- a/packages/hermes-api/tests/test_api/test_auth.py
+++ b/packages/hermes-api/tests/test_api/test_auth.py
@@ -116,6 +116,44 @@ class TestAuthentication:
         assert response.status_code in [403, 307]
 
     @pytest.mark.asyncio
+    async def test_invalid_long_api_key_is_rejected(self, client: AsyncClient):
+        """Test long bearer strings are not accepted unless they match a stored key."""
+        from app.main import app
+
+        app.dependency_overrides.clear()
+
+        response = await client.get(
+            "/api/v1/queue/",
+            headers={"Authorization": "Bearer definitely-not-a-real-api-key-123456"},
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_database_api_key_authenticates(
+        self, client: AsyncClient, test_user, auth_token
+    ):
+        """Test database-backed API keys are validated by the shared dependency."""
+        from app.main import app
+
+        app.dependency_overrides.clear()
+
+        create_response = await client.post(
+            "/api/v1/auth/api-keys",
+            headers={"Authorization": f"Bearer {auth_token}"},
+            json={"name": "Shared Dependency Key", "permissions": ["read"]},
+        )
+        assert create_response.status_code == 200
+
+        api_key = create_response.json()["key"]
+        response = await client.get(
+            "/api/v1/queue/",
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+
+        assert response.status_code != 401
+
+    @pytest.mark.asyncio
     async def test_rate_limiting_login(self, client: AsyncClient):
         """Test rate limiting on login endpoint."""
         # Clear any auth overrides for this test

--- a/packages/hermes-api/tests/test_api/test_events.py
+++ b/packages/hermes-api/tests/test_api/test_events.py
@@ -42,7 +42,7 @@ class TestSSETokenEndpoint:
     async def test_create_token_requires_auth(self, client: AsyncClient):
         """Test that token creation requires authentication."""
         # Clear auth override to test actual auth
-        from app.core.security import get_current_api_key
+        from app.core.security import get_current_principal
         from app.main import app
 
         # Override with a function that raises 401
@@ -51,7 +51,7 @@ class TestSSETokenEndpoint:
 
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
 
-        app.dependency_overrides[get_current_api_key] = mock_no_auth
+        app.dependency_overrides[get_current_principal] = mock_no_auth
 
         response = await client.post(
             "/api/v1/events/token", json={"scope": "queue", "ttl": 600}

--- a/packages/hermes-app/src/components/auth/ProtectedRoute.tsx
+++ b/packages/hermes-app/src/components/auth/ProtectedRoute.tsx
@@ -8,10 +8,10 @@ interface ProtectedRouteProps {
 }
 
 export function ProtectedRoute({ children, requireAuth = true }: ProtectedRouteProps) {
-  const { isAuthenticated, isLoading } = useAuth()
+  const { isAuthenticated, isLoading, isValidating } = useAuth()
   const location = useLocation()
 
-  if (isLoading) {
+  if (isLoading || isValidating) {
     return (
       <div className="flex items-center justify-center min-h-screen">
         <Loader2 className="h-8 w-8 animate-spin" />
@@ -31,7 +31,6 @@ export function ProtectedRoute({ children, requireAuth = true }: ProtectedRouteP
 
   return <>{children}</>
 }
-
 
 
 


### PR DESCRIPTION
## Summary
- add a unified AuthPrincipal resolver for JWT users, configured API keys, and database API keys
- validate database API keys in the shared auth dependency instead of accepting marker strings
- route user/admin auth and SSE token creation through the unified principal path
- wait for frontend auth validation in ProtectedRoute before redirecting

## Why
The previous API-key dependency accepted long bearer strings as db_api_key markers before most routes verified them. Centralizing principal resolution makes every protected route validate the caller before route logic runs.

## Validation
- uv run pytest tests/test_api/test_auth.py tests/test_api/test_api_keys.py tests/test_api/test_events.py tests/test_integration/test_api_key_flow.py
- uv run ruff check app/core/security.py app/api/dependencies.py app/api/v1/endpoints/downloads.py app/api/v1/endpoints/events.py tests/conftest.py tests/test_api/test_auth.py tests/test_api/test_events.py
- pnpm --filter hermes-app type-check
- pnpm --filter hermes-app lint