### PR TITLE
Fix first-run signup and completed downloads

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -36,7 +36,7 @@ services:
       api:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:5173/"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:5173/"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/packages/hermes-api/app/api/v1/endpoints/config.py
+++ b/packages/hermes-api/app/api/v1/endpoints/config.py
@@ -2,9 +2,12 @@
 Configuration management endpoints.
 """
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.logging import get_logger
+from app.db.repositories import UserRepository
+from app.db.session import get_database_session
 from app.models.base import CamelCaseModel
 from app.services.system_settings_service import system_settings_service
 
@@ -19,7 +22,9 @@ class PublicConfig(CamelCaseModel):
 
 
 @router.get("/public", response_model=PublicConfig)
-async def get_public_configuration():
+async def get_public_configuration(
+    db_session: AsyncSession = Depends(get_database_session),
+):
     """
     Get public configuration settings.
 
@@ -28,4 +33,15 @@ async def get_public_configuration():
     such as whether public signup is allowed.
     """
     allow_public_signup = await system_settings_service.get_allow_public_signup()
-    return PublicConfig(allow_public_signup=allow_public_signup)
+    try:
+        user_count = await UserRepository(db_session).count()
+    except Exception as e:
+        logger.warning(
+            "Unable to check user count for public config; using signup setting",
+            error=str(e),
+        )
+        user_count = 1
+
+    return PublicConfig(
+        allow_public_signup=allow_public_signup or user_count == 0,
+    )

--- a/packages/hermes-api/tests/test_api/test_signup_restrictions.py
+++ b/packages/hermes-api/tests/test_api/test_signup_restrictions.py
@@ -225,10 +225,10 @@ class TestPublicConfigEndpoint:
         assert data["allowPublicSignup"] is True
 
     @pytest.mark.asyncio
-    async def test_public_config_with_signup_disabled(
-        self, client: AsyncClient, monkeypatch
+    async def test_public_config_with_signup_disabled_and_existing_user(
+        self, client: AsyncClient, monkeypatch, test_user
     ):
-        """Test public config endpoint when signup is disabled."""
+        """Test public config endpoint when signup is disabled and users exist."""
         # Clear any auth overrides for this test
         from app.main import app
 
@@ -243,6 +243,25 @@ class TestPublicConfigEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert data["allowPublicSignup"] is False
+
+    @pytest.mark.asyncio
+    async def test_public_config_allows_first_user_signup(
+        self, client: AsyncClient, monkeypatch
+    ):
+        """Test public config allows signup when no users exist."""
+        # Clear any auth overrides for this test
+        from app.main import app
+
+        app.dependency_overrides.clear()
+
+        from app.core import config
+
+        monkeypatch.setattr(config.settings, "allow_public_signup", False)
+
+        response = await client.get("/api/v1/config/public")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["allowPublicSignup"] is True
 
     @pytest.mark.asyncio
     async def test_public_config_no_auth_required(self, client: AsyncClient):

--- a/packages/hermes-app/src/hooks/useDownloadProgressSSE.test.tsx
+++ b/packages/hermes-app/src/hooks/useDownloadProgressSSE.test.tsx
@@ -328,7 +328,57 @@ describe('useDownloadProgressSSE', () => {
       const { result } = renderHook(() => useDownloadProgressSSE(mockDownloadId), { wrapper: createWrapper() })
 
       await waitFor(() => {
-        expect(result.current.data).toEqual(mockDownloadStatus)
+        expect(result.current.data).toEqual({
+          downloadId: mockDownloadId,
+          status: 'downloading',
+          progress: mockDownloadStatus.progress,
+          result: null,
+          currentFilename: null,
+          message: '',
+          error: null,
+          createdAt: expect.any(String),
+        })
+      })
+    })
+
+    it('maps completed SSE output path to current filename', async () => {
+      const mockCreateSSEToken = vi.fn().mockResolvedValue({
+        token: mockSSEToken,
+        expires_at: '2025-12-31T23:59:59Z',
+        scope: `download:${mockDownloadId}`,
+        permissions: ['read'],
+        ttl: 600,
+      })
+
+      vi.spyOn(apiClientModule, 'apiClient', 'get').mockReturnValue({
+        createSSEToken: mockCreateSSEToken,
+      } as any)
+
+      vi.spyOn(useSSEModule, 'useSSE').mockReturnValue({
+        data: {
+          download_id: mockDownloadId,
+          status: 'completed',
+          output_path: './downloads/example.mp4',
+          result: {
+            title: 'Example',
+            file_size: 1024,
+            thumbnail_url: 'https://example.com/thumb.jpg',
+          },
+        },
+        isConnected: true,
+        error: null,
+        isReconnecting: false,
+        reconnectAttempts: 0,
+        close: vi.fn(),
+        reconnect: vi.fn(),
+      })
+
+      const { result } = renderHook(() => useDownloadProgressSSE(mockDownloadId), { wrapper: createWrapper() })
+
+      await waitFor(() => {
+        expect(result.current.data?.currentFilename).toBe('./downloads/example.mp4')
+        expect(result.current.data?.result?.fileSize).toBe(1024)
+        expect(result.current.data?.result?.thumbnailUrl).toBe('https://example.com/thumb.jpg')
       })
     })
 

--- a/packages/hermes-app/src/hooks/useDownloadProgressSSE.ts
+++ b/packages/hermes-app/src/hooks/useDownloadProgressSSE.ts
@@ -7,6 +7,49 @@ import type { components } from '@/types/api.generated';
 
 type DownloadStatus = components["schemas"]["DownloadStatus"];
 
+type RawDownloadStatus = Partial<DownloadStatus> & {
+  download_id?: string;
+  current_filename?: string | null;
+  output_path?: string | null;
+  error_message?: string | null;
+  created_at?: string;
+  result?: (DownloadStatus['result'] & {
+    file_size?: number | null;
+    thumbnail_url?: string | null;
+  }) | null;
+};
+
+function normalizeDownloadStatus(raw: RawDownloadStatus): DownloadStatus | null {
+  const downloadId = raw.downloadId ?? raw.download_id;
+
+  if (!downloadId || !raw.status) {
+    return null;
+  }
+
+  const result = raw.result
+    ? {
+        url: raw.result.url,
+        title: raw.result.title,
+        fileSize: raw.result.fileSize ?? raw.result.file_size,
+        duration: raw.result.duration,
+        thumbnailUrl: raw.result.thumbnailUrl ?? raw.result.thumbnail_url,
+        extractor: raw.result.extractor,
+        description: raw.result.description,
+      }
+    : raw.result;
+
+  return {
+    downloadId,
+    status: raw.status,
+    progress: raw.progress,
+    currentFilename: raw.currentFilename ?? raw.current_filename ?? raw.output_path ?? null,
+    message: raw.message ?? `Download ${raw.status}`,
+    error: raw.error ?? raw.error_message ?? null,
+    result,
+    createdAt: raw.createdAt ?? raw.created_at ?? new Date().toISOString(),
+  };
+}
+
 /**
  * Hook for real-time download progress updates via SSE
  *
@@ -59,23 +102,28 @@ export function useDownloadProgressSSE(downloadId: string) {
     []
   );
 
-  const { data, isConnected, error, isReconnecting, reconnectAttempts } = useSSE<DownloadStatus>(
+  const { data, isConnected, error, isReconnecting, reconnectAttempts } = useSSE<RawDownloadStatus>(
     sseUrl,
     sseOptions
   );
 
+  const normalizedData = useMemo(
+    () => data ? normalizeDownloadStatus(data as RawDownloadStatus) : null,
+    [data]
+  );
+
   // Update React Query cache when SSE data arrives
   useEffect(() => {
-    if (data && data.downloadId === downloadId) {
+    if (normalizedData && normalizedData.downloadId === downloadId) {
       queryClient.setQueryData(
         ['download', 'progress', downloadId],
-        data
+        normalizedData
       );
     }
-  }, [data, downloadId, queryClient]);
+  }, [normalizedData, downloadId, queryClient]);
 
   return {
-    data,
+    data: normalizedData,
     isConnected,
     error: tokenError || error, // Return token error if token fetch failed
     isReconnecting,

--- a/packages/hermes-app/src/routes/index.tsx
+++ b/packages/hermes-app/src/routes/index.tsx
@@ -12,6 +12,8 @@ import { useState, useEffect, useCallback } from 'react'
 import { useDownloadFile } from '@/hooks/useDownloadActions'
 import { Blur } from '@/components/animate-ui/primitives/effects/blur'
 import { taskTracker } from '@/lib/taskTracking'
+import { apiClient } from '@/services/api/client'
+import { toast } from 'sonner'
 import type { DownloadResult } from '@/types'
 
 // Type guard to check if result has the expected download result properties
@@ -32,13 +34,27 @@ function TrackedTask({ downloadId, onRemove, isDismissing }: TrackedTaskProps) {
 
   const downloadFile = useDownloadFile()
 
-  const handleDownloadFile = (filePath: string | null | undefined, title: string, downloadId: string) => {
-    if (!filePath) {
+  const handleDownloadFile = async (filePath: string | null | undefined, title: string, downloadId: string) => {
+    let resolvedFilePath = filePath
+
+    if (!resolvedFilePath) {
+      try {
+        const status = await apiClient.getDownloadStatus(downloadId)
+        resolvedFilePath = status.currentFilename
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        toast.error(`Failed to get download file: ${message}`)
+        return
+      }
+    }
+
+    if (!resolvedFilePath) {
+      toast.error('File path is not available for this download yet.')
       return
     }
 
     downloadFile.mutate(
-      { filePath, title },
+      { filePath: resolvedFilePath, title },
       {
         onSuccess: () => {
           // Auto-dismiss task after successful download


### PR DESCRIPTION
## Summary
- report signup as available for first-run setup when no users exist, matching backend signup behavior
- normalize download SSE payloads so completed dashboard cards receive currentFilename and result fields
- add click-time status fallback for completed download buttons and fix the dev frontend healthcheck IPv4 probe

## Tests
- uv run pytest tests/test_api/test_signup_restrictions.py
- pnpm --dir packages/hermes-app type-check
- pnpm --dir packages/hermes-app exec vitest run src/hooks/useDownloadProgressSSE.test.tsx