### PR TITLE
[codex] Enforce API key permissions

### DIFF
--- a/packages/hermes-api/app/api/v1/endpoints/auth.py
+++ b/packages/hermes-api/app/api/v1/endpoints/auth.py
@@ -15,6 +15,7 @@ from app.api.dependencies import get_current_user_from_token
 from app.core.config import settings
 from app.core.logging import get_logger
 from app.core.security import (
+    ApiKeyPermission,
     create_access_token,
     create_api_key,
     create_refresh_token,
@@ -519,7 +520,7 @@ class ApiKeyCreate(CamelCaseModel):
     """API key creation request with automatic camelCase conversion."""
 
     name: str = Field(..., min_length=1, max_length=100, description="API key name")
-    permissions: list[str] = Field(default_factory=list)
+    permissions: list[ApiKeyPermission] = Field(default_factory=list)
     expires_at: datetime | None = None
 
 
@@ -622,8 +623,9 @@ async def create_api_key_endpoint(
             user_id=current_user["id"],
             name=api_key_data.name,
             key_hash=key_hash,
-            permissions=api_key_data.permissions,
+            permissions=[permission.value for permission in api_key_data.permissions],
             rate_limit=60,  # Default rate limit
+            expires_at=api_key_data.expires_at,
         )
 
         logger.info(

--- a/packages/hermes-api/app/api/v1/endpoints/cleanup.py
+++ b/packages/hermes-api/app/api/v1/endpoints/cleanup.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.logging import get_logger
-from app.core.security import get_current_api_key
+from app.core.security import ApiKeyPermission, AuthPrincipal, require_api_permission
 from app.db.repositories import TokenBlacklistRepository
 from app.db.session import get_database_session
 from app.models.pydantic.cleanup import CleanupRequest, CleanupResponse
@@ -31,7 +31,7 @@ def get_repositories_from_session(db_session: AsyncSession):
 async def cleanup_downloads(
     request: CleanupRequest = CleanupRequest(),
     db_session: AsyncSession = Depends(get_database_session),
-    api_key: str = Depends(get_current_api_key),
+    principal: AuthPrincipal = Depends(require_api_permission(ApiKeyPermission.WRITE)),
 ):
     """
     Clean up old downloads and temporary files.
@@ -144,7 +144,7 @@ async def cleanup_downloads(
 async def cleanup_expired_tokens(
     dry_run: bool = False,
     db_session: AsyncSession = Depends(get_database_session),
-    api_key: str = Depends(get_current_api_key),
+    principal: AuthPrincipal = Depends(require_api_permission(ApiKeyPermission.WRITE)),
 ):
     """
     Clean up expired tokens from the blacklist.

--- a/packages/hermes-api/app/api/v1/endpoints/downloads.py
+++ b/packages/hermes-api/app/api/v1/endpoints/downloads.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.logging import get_logger
-from app.core.security import get_current_api_key
+from app.core.security import ApiKeyPermission, AuthPrincipal, require_api_permission
 from app.db.repositories import DownloadRepository
 from app.db.session import get_database_session
 from app.models.pydantic.download import (
@@ -37,7 +37,7 @@ def get_repositories_from_session(db_session: AsyncSession):
 async def start_download(
     download_request: DownloadRequest,  # Renamed from 'request' to avoid conflicts
     db_session: AsyncSession = Depends(get_database_session),
-    api_key: str = Depends(get_current_api_key),
+    principal: AuthPrincipal = Depends(require_api_permission(ApiKeyPermission.WRITE)),
 ) -> DownloadResponse:
     """
     Start a new video download.
@@ -130,7 +130,7 @@ async def start_download(
 async def get_download_status(
     download_id: str,
     db_session: AsyncSession = Depends(get_database_session),
-    api_key: str = Depends(get_current_api_key),
+    principal: AuthPrincipal = Depends(require_api_permission(ApiKeyPermission.READ)),
 ) -> DownloadStatus:
     """Get the status of a download."""
     try:
@@ -217,7 +217,7 @@ async def get_download_status(
 async def cancel_download(
     download_id: str,
     db_session: AsyncSession = Depends(get_database_session),
-    api_key: str = Depends(get_current_api_key),
+    principal: AuthPrincipal = Depends(require_api_permission(ApiKeyPermission.WRITE)),
 ) -> CancelResponse:
     """Cancel a running download."""
     try:
@@ -261,7 +261,7 @@ async def start_batch_download(
     batch_request: BatchDownloadRequest,  # Renamed from 'request' to avoid conflicts
     background_tasks: BackgroundTasks,
     db_session: AsyncSession = Depends(get_database_session),
-    api_key: str = Depends(get_current_api_key),
+    principal: AuthPrincipal = Depends(require_api_permission(ApiKeyPermission.WRITE)),
 ) -> BatchDownloadResponse:
     """
     Start a batch download of multiple videos.

--- a/packages/hermes-api/app/api/v1/endpoints/events.py
+++ b/packages/hermes-api/app/api/v1/endpoints/events.py
@@ -11,9 +11,10 @@ from sse_starlette.sse import EventSourceResponse
 from app.core.config import settings
 from app.core.logging import get_logger
 from app.core.security import (
+    ApiKeyPermission,
     AuthPrincipal,
-    get_current_principal,
     get_current_sse_token,
+    require_api_permission,
     validate_sse_token,
 )
 from app.db.repositories import DownloadRepository
@@ -310,7 +311,7 @@ async def stats_events(
 @router.post("/token", response_model=SSETokenResponse)
 async def create_sse_token(
     request: CreateSSETokenRequest = Body(...),
-    principal: AuthPrincipal = Depends(get_current_principal),
+    principal: AuthPrincipal = Depends(require_api_permission(ApiKeyPermission.READ)),
     db_session: AsyncSession = Depends(get_database_session),
 ):
     """

--- a/packages/hermes-api/app/api/v1/endpoints/files.py
+++ b/packages/hermes-api/app/api/v1/endpoints/files.py
@@ -10,7 +10,7 @@ from fastapi.responses import FileResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.logging import get_logger
-from app.core.security import get_current_api_key
+from app.core.security import ApiKeyPermission, AuthPrincipal, require_api_permission
 from app.db.repositories import DownloadFileRepository, DownloadRepository
 from app.db.session import get_database_session
 from app.models.pydantic.file import (
@@ -35,7 +35,9 @@ def get_repositories_from_session(db_session: AsyncSession):
 @router.get("/download")
 async def download_file(
     path: str = Query(..., description="File path to download"),
-    api_key: str = Depends(get_current_api_key),
+    principal: AuthPrincipal = Depends(
+        require_api_permission(ApiKeyPermission.DOWNLOAD)
+    ),
 ) -> FileResponse:
     """Download a specific file."""
     try:
@@ -77,7 +79,7 @@ async def list_downloaded_files(
     ),
     offset: int = Query(0, ge=0, description="Number of items to skip"),
     db_session: AsyncSession = Depends(get_database_session),
-    api_key: str = Depends(get_current_api_key),
+    principal: AuthPrincipal = Depends(require_api_permission(ApiKeyPermission.READ)),
 ) -> FileList:
     """List all files that have been downloaded and are currently stored."""
     try:
@@ -142,7 +144,7 @@ async def list_downloaded_files(
 async def delete_downloaded_files(
     request: DeleteFilesRequest,
     db_session: AsyncSession = Depends(get_database_session),
-    api_key: str = Depends(get_current_api_key),
+    principal: AuthPrincipal = Depends(require_api_permission(ApiKeyPermission.WRITE)),
 ) -> DeleteFilesResponse:
     """Delete one or more downloaded files from storage."""
     try:

--- a/packages/hermes-api/app/api/v1/endpoints/history.py
+++ b/packages/hermes-api/app/api/v1/endpoints/history.py
@@ -13,7 +13,7 @@ from sqlalchemy import Integer, and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.logging import get_logger
-from app.core.security import get_current_api_key
+from app.core.security import ApiKeyPermission, AuthPrincipal, require_api_permission
 from app.db.models import DownloadHistory as DownloadHistoryModel
 from app.db.session import get_database_session
 from app.models.pydantic.history import (
@@ -113,7 +113,7 @@ async def get_download_history(
     ),
     offset: int = Query(0, ge=0, description="Number of items to skip"),
     db_session: AsyncSession = Depends(get_database_session),
-    api_key: str = Depends(get_current_api_key),
+    principal: AuthPrincipal = Depends(require_api_permission(ApiKeyPermission.READ)),
 ):
     """
     Get download history with statistics.

--- a/packages/hermes-api/app/api/v1/endpoints/queue.py
+++ b/packages/hermes-api/app/api/v1/endpoints/queue.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.logging import get_logger
-from app.core.security import get_current_api_key
+from app.core.security import ApiKeyPermission, AuthPrincipal, require_api_permission
 from app.db.repositories import DownloadRepository
 from app.db.session import get_database_session
 from app.models.pydantic.download import CleanupOrphanedResponse, DownloadQueue
@@ -33,7 +33,7 @@ async def get_download_queue(
     ),
     offset: int = Query(0, ge=0, description="Number of items to skip"),
     db_session: AsyncSession = Depends(get_database_session),
-    api_key: str = Depends(get_current_api_key),
+    principal: AuthPrincipal = Depends(require_api_permission(ApiKeyPermission.READ)),
 ) -> DownloadQueue:
     """Get the current download queue with all pending, active, and recently completed downloads."""
     try:
@@ -166,7 +166,7 @@ async def get_download_queue(
 async def cleanup_orphaned_downloads(
     dry_run: bool = False,
     db_session: AsyncSession = Depends(get_database_session),
-    api_key: str = Depends(get_current_api_key),
+    principal: AuthPrincipal = Depends(require_api_permission(ApiKeyPermission.WRITE)),
 ) -> CleanupOrphanedResponse:
     """
     Clean up orphaned download records where files no longer exist on disk.

--- a/packages/hermes-api/app/api/v1/endpoints/stats.py
+++ b/packages/hermes-api/app/api/v1/endpoints/stats.py
@@ -9,7 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.logging import get_logger
-from app.core.security import get_current_api_key
+from app.core.security import ApiKeyPermission, AuthPrincipal, require_api_permission
 from app.db.models import DownloadHistory
 from app.db.session import get_database_session
 from app.models.pydantic.stats import ApiStatistics, ErrorBreakdown, ExtractorStats
@@ -24,7 +24,7 @@ async def get_api_statistics(
         "week", description="Time period for statistics (day, week, month, year)"
     ),
     db_session: AsyncSession = Depends(get_database_session),
-    api_key: str = Depends(get_current_api_key),
+    principal: AuthPrincipal = Depends(require_api_permission(ApiKeyPermission.READ)),
 ):
     """
     Get API usage statistics.

--- a/packages/hermes-api/app/api/v1/endpoints/storage.py
+++ b/packages/hermes-api/app/api/v1/endpoints/storage.py
@@ -5,7 +5,7 @@ Storage information endpoint.
 from fastapi import APIRouter, Depends
 
 from app.core.logging import get_logger
-from app.core.security import get_current_api_key
+from app.core.security import ApiKeyPermission, AuthPrincipal, require_api_permission
 from app.models.pydantic.storage import StorageInfo
 from app.services.storage_service import StorageService
 
@@ -14,7 +14,9 @@ logger = get_logger(__name__)
 
 
 @router.get("/", response_model=StorageInfo)
-async def get_storage_info(api_key: str = Depends(get_current_api_key)):
+async def get_storage_info(
+    principal: AuthPrincipal = Depends(require_api_permission(ApiKeyPermission.READ)),
+):
     """
     Get storage usage information and cleanup recommendations.
 

--- a/packages/hermes-api/app/api/v1/endpoints/timeline.py
+++ b/packages/hermes-api/app/api/v1/endpoints/timeline.py
@@ -11,7 +11,7 @@ from sqlalchemy import Integer, and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.logging import get_logger
-from app.core.security import get_current_api_key
+from app.core.security import ApiKeyPermission, AuthPrincipal, require_api_permission
 from app.db.models import DownloadHistory as DownloadHistoryModel
 from app.db.session import get_database_session
 from app.models.pydantic.history import DailyStats, TimelineSummary
@@ -30,7 +30,7 @@ async def get_timeline_stats(
     extractor: Optional[str] = Query(None, description="Filter by extractor"),
     status: Optional[str] = Query(None, description="Filter by status"),
     db_session: AsyncSession = Depends(get_database_session),
-    api_key: str = Depends(get_current_api_key),
+    principal: AuthPrincipal = Depends(require_api_permission(ApiKeyPermission.READ)),
 ):
     """
     Get timeline data for charts and visualizations.
@@ -134,7 +134,7 @@ async def get_timeline_summary(
     ),
     end_date: Optional[date_type] = Query(None, description="End date (YYYY-MM-DD)"),
     db_session: AsyncSession = Depends(get_database_session),
-    api_key: str = Depends(get_current_api_key),
+    principal: AuthPrincipal = Depends(require_api_permission(ApiKeyPermission.READ)),
 ):
     """
     Get summary statistics for the timeline period.
@@ -151,7 +151,7 @@ async def get_timeline_summary(
             extractor=None,
             status=None,
             db_session=db_session,
-            api_key=api_key,
+            principal=principal,
         )
 
         if not daily_stats:

--- a/packages/hermes-api/app/core/security.py
+++ b/packages/hermes-api/app/core/security.py
@@ -6,6 +6,7 @@ import hashlib
 import secrets
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
+from enum import StrEnum
 from typing import List, Literal, Optional
 
 import bcrypt
@@ -30,6 +31,15 @@ security = HTTPBearer()
 
 # Optional HTTP Bearer for SSE endpoints (doesn't raise error if missing)
 optional_security = HTTPBearer(auto_error=False)
+
+
+class ApiKeyPermission(StrEnum):
+    """Supported permissions for database-backed API keys."""
+
+    READ = "read"
+    WRITE = "write"
+    DOWNLOAD = "download"
+    ADMIN = "admin"
 
 
 @dataclass(frozen=True)
@@ -422,6 +432,29 @@ class PermissionChecker:
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=f"Permission denied: {required_permission} required",
             )
+
+
+def require_api_permission(required_permission: ApiKeyPermission | str):
+    """FastAPI dependency factory that enforces permissions for API key callers."""
+
+    required_permission_value = (
+        required_permission.value
+        if isinstance(required_permission, ApiKeyPermission)
+        else required_permission
+    )
+
+    async def dependency(
+        principal: AuthPrincipal = Depends(get_current_principal),
+    ) -> AuthPrincipal:
+        if principal.kind == "user":
+            return principal
+
+        PermissionChecker.require_permission(
+            principal.permissions, required_permission_value
+        )
+        return principal
+
+    return dependency
 
 
 # =============================================================================

--- a/packages/hermes-api/app/db/repositories.py
+++ b/packages/hermes-api/app/db/repositories.py
@@ -303,6 +303,7 @@ class ApiKeyRepository(BaseRepository):
         key_hash: str,
         permissions: List[str] = None,
         rate_limit: int = 60,
+        expires_at: datetime = None,
     ) -> ApiKey:
         """Create a new API key."""
         key_id = str(uuid.uuid4())
@@ -316,6 +317,7 @@ class ApiKeyRepository(BaseRepository):
             rate_limit=rate_limit,
             is_active=True,
             created_at=datetime.now(timezone.utc),
+            expires_at=expires_at,
         )
 
         self.session.add(api_key)

--- a/packages/hermes-api/tests/test_api/test_auth.py
+++ b/packages/hermes-api/tests/test_api/test_auth.py
@@ -2,6 +2,8 @@
 Tests for authentication endpoints and token validation.
 """
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 from httpx import AsyncClient
 
@@ -386,6 +388,46 @@ class TestApiKeyManagement:
         assert len(data["key"]) > 32  # Should be a long API key
 
     @pytest.mark.asyncio
+    async def test_create_api_key_rejects_unknown_permission(
+        self, client: AsyncClient, test_user, auth_token
+    ):
+        """Test API key creation rejects unsupported permissions."""
+        from app.main import app
+
+        app.dependency_overrides.clear()
+
+        response = await client.post(
+            "/api/v1/auth/api-keys",
+            headers={"Authorization": f"Bearer {auth_token}"},
+            json={"name": "Bad Permission Key", "permissions": ["read", "export"]},
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_create_api_key_persists_expiration(
+        self, client: AsyncClient, test_user, auth_token
+    ):
+        """Test API key creation stores expiresAt."""
+        from app.main import app
+
+        app.dependency_overrides.clear()
+
+        expires_at = datetime.now(timezone.utc) + timedelta(days=7)
+        response = await client.post(
+            "/api/v1/auth/api-keys",
+            headers={"Authorization": f"Bearer {auth_token}"},
+            json={
+                "name": "Expiring Key",
+                "permissions": ["read"],
+                "expiresAt": expires_at.isoformat(),
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["expiresAt"] is not None
+
+    @pytest.mark.asyncio
     async def test_create_api_key_no_auth(self, client: AsyncClient):
         """Test API key creation requires authentication."""
         # Clear any auth overrides for this test
@@ -569,16 +611,74 @@ class TestApiKeyAuthentication:
         )
         api_key = create_response.json()["key"]
 
-        # Test API key validation in download endpoint
+        # A read-only API key authenticates successfully but cannot write.
         response = await client.post(
-            "/api/v1/download",
+            "/api/v1/download/",
             headers={"Authorization": f"Bearer {api_key}"},
             json={"url": "https://youtube.com/watch?v=test"},
         )
 
-        # The endpoint should accept the API key (might fail for other reasons)
-        # But it should NOT fail with 401 (unauthorized)
-        assert response.status_code != 401
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_database_api_key_permissions_by_route(
+        self, client: AsyncClient, test_user, auth_token, tmp_path
+    ):
+        """Test read, write, and download permissions are distinct."""
+        from app.main import app
+
+        app.dependency_overrides.clear()
+
+        read_response = await client.post(
+            "/api/v1/auth/api-keys",
+            headers={"Authorization": f"Bearer {auth_token}"},
+            json={"name": "Read Key", "permissions": ["read"]},
+        )
+        write_response = await client.post(
+            "/api/v1/auth/api-keys",
+            headers={"Authorization": f"Bearer {auth_token}"},
+            json={"name": "Write Key", "permissions": ["write"]},
+        )
+        download_response = await client.post(
+            "/api/v1/auth/api-keys",
+            headers={"Authorization": f"Bearer {auth_token}"},
+            json={"name": "Download Key", "permissions": ["download"]},
+        )
+
+        read_key = read_response.json()["key"]
+        write_key = write_response.json()["key"]
+        download_key = download_response.json()["key"]
+        file_path = tmp_path / "sample.txt"
+        file_path.write_text("sample")
+
+        read_allowed = await client.get(
+            "/api/v1/queue/", headers={"Authorization": f"Bearer {read_key}"}
+        )
+        read_denied_write = await client.post(
+            "/api/v1/download/",
+            headers={"Authorization": f"Bearer {read_key}"},
+            json={"url": "https://youtube.com/watch?v=test"},
+        )
+        write_denied_download = await client.get(
+            "/api/v1/files/download",
+            headers={"Authorization": f"Bearer {write_key}"},
+            params={"path": str(file_path)},
+        )
+        download_denied_read = await client.get(
+            "/api/v1/queue/",
+            headers={"Authorization": f"Bearer {download_key}"},
+        )
+        download_allowed = await client.get(
+            "/api/v1/files/download",
+            headers={"Authorization": f"Bearer {download_key}"},
+            params={"path": str(file_path)},
+        )
+
+        assert read_allowed.status_code == 200
+        assert read_denied_write.status_code == 403
+        assert write_denied_download.status_code == 403
+        assert download_denied_read.status_code == 403
+        assert download_allowed.status_code == 200
 
 
 class TestApiKeySecurity:

--- a/packages/hermes-api/tests/test_integration/test_api_key_flow.py
+++ b/packages/hermes-api/tests/test_integration/test_api_key_flow.py
@@ -24,7 +24,10 @@ class TestApiKeyIntegration:
         create_response = client.post(
             "/api/v1/auth/api-keys",
             headers={"Authorization": f"Bearer {auth_token}"},
-            json={"name": "Integration Test Key", "permissions": ["read", "download"]},
+            json={
+                "name": "Integration Test Key",
+                "permissions": ["read", "write", "download"],
+            },
         )
         assert create_response.status_code == 200
 
@@ -87,7 +90,7 @@ class TestApiKeyIntegration:
         create_response = client.post(
             "/api/v1/auth/api-keys",
             headers={"Authorization": f"Bearer {auth_token}"},
-            json={"name": "Auth Test Key", "permissions": ["read"]},
+            json={"name": "Auth Test Key", "permissions": ["write"]},
         )
         api_key = create_response.json()["key"]
 


### PR DESCRIPTION
## Summary
- add a typed API key permission enum and permission dependency for protected API routes
- enforce read, write, download, and admin semantics across download, file, queue, cleanup, analytics, storage, and SSE token endpoints
- validate API key permission names and persist expiresAt during key creation

## Why
API key permissions were stored but not enforced, making read and download effectively identical. This makes read metadata access distinct from downloading file bytes and write operations.

## Validation
- cd packages/hermes-api && uv run ruff check app/ tests/
- cd packages/hermes-api && uv run python -m mypy --explicit-package-bases app/ tests/
- cd packages/hermes-api && uv run pytest

## Notes
- Full API test suite: 246 passed, 5 skipped, 1 warning.