### PR TITLE
[codex] fix CI build version display

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -80,6 +80,8 @@ jobs:
           push: true
           tags: ${{ steps.meta-app.outputs.tags }}
           labels: ${{ steps.meta-app.outputs.labels }}
+          build-args: |
+            VITE_HERMES_BUILD_VERSION=develop-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
@@ -101,6 +103,8 @@ jobs:
           push: true
           tags: ${{ steps.meta-api.outputs.tags }}
           labels: ${{ steps.meta-api.outputs.labels }}
+          build-args: |
+            HERMES_BUILD_VERSION=develop-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish-release-images.yml
+++ b/.github/workflows/publish-release-images.yml
@@ -119,6 +119,8 @@ jobs:
           push: true
           tags: ${{ steps.meta-app.outputs.tags }}
           labels: ${{ steps.meta-app.outputs.labels }}
+          build-args: |
+            VITE_HERMES_BUILD_VERSION=${{ env.RELEASE_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
@@ -142,6 +144,8 @@ jobs:
           push: true
           tags: ${{ steps.meta-api.outputs.tags }}
           labels: ${{ steps.meta-api.outputs.labels }}
+          build-args: |
+            HERMES_BUILD_VERSION=${{ env.RELEASE_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,6 +204,8 @@ jobs:
           push: true
           tags: ${{ steps.meta-app.outputs.tags }}
           labels: ${{ steps.meta-app.outputs.labels }}
+          build-args: |
+            VITE_HERMES_BUILD_VERSION=v${{ steps.new_version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
@@ -227,6 +229,8 @@ jobs:
           push: true
           tags: ${{ steps.meta-api.outputs.tags }}
           labels: ${{ steps.meta-api.outputs.labels }}
+          build-args: |
+            HERMES_BUILD_VERSION=v${{ steps.new_version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64

--- a/packages/hermes-api/Dockerfile
+++ b/packages/hermes-api/Dockerfile
@@ -27,6 +27,7 @@ FROM python:3.13-slim
 # Override at build time: docker build --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g)
 ARG USER_UID=1000
 ARG USER_GID=1000
+ARG HERMES_BUILD_VERSION
 
 # Install only runtime dependencies
 RUN apt-get update && apt-get install -y \
@@ -68,6 +69,7 @@ USER hermes
 
 # Set environment variables for security and performance
 ENV PATH="/app/.venv/bin:$PATH" \
+    HERMES_BUILD_VERSION="${HERMES_BUILD_VERSION}" \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 

--- a/packages/hermes-api/app/core/config.py
+++ b/packages/hermes-api/app/core/config.py
@@ -1,5 +1,6 @@
 import importlib.metadata
 import json
+import os
 import re
 from typing import Any, Optional
 
@@ -53,7 +54,11 @@ class Settings(BaseSettings):
 
     @property
     def api_version(self) -> str:
-        """Get version from pyproject.toml or package metadata."""
+        """Get version from CI build metadata, package metadata, or pyproject.toml."""
+        build_version = os.getenv("HERMES_BUILD_VERSION", "").strip()
+        if build_version:
+            return build_version
+
         # Try to get from installed package metadata first
         try:
             return importlib.metadata.version("hermes-api")

--- a/packages/hermes-api/tests/test_api/test_health.py
+++ b/packages/hermes-api/tests/test_api/test_health.py
@@ -19,6 +19,18 @@ class TestHealth:
         assert "timestamp" in data
 
     @pytest.mark.asyncio
+    async def test_health_check_uses_build_version(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Test health check prefers CI-provided build version."""
+        monkeypatch.setenv("HERMES_BUILD_VERSION", "v0.4.0")
+
+        response = await client.get("/api/v1/health/")
+
+        assert response.status_code == 200
+        assert response.json()["version"] == "v0.4.0"
+
+    @pytest.mark.asyncio
     async def test_detailed_health_check(self, client: AsyncClient):
         """Test detailed health check endpoint."""
         response = await client.get("/api/v1/health/detailed")

--- a/packages/hermes-app/Dockerfile
+++ b/packages/hermes-app/Dockerfile
@@ -20,6 +20,8 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 # Build the application - optimized layer caching
 FROM base AS builder
 WORKDIR /app
+ARG VITE_HERMES_BUILD_VERSION
+ENV VITE_HERMES_BUILD_VERSION=${VITE_HERMES_BUILD_VERSION}
 
 # Copy dependencies from deps stage
 COPY --from=deps /app/node_modules ./node_modules

--- a/packages/hermes-app/src/components/version-status.tsx
+++ b/packages/hermes-app/src/components/version-status.tsx
@@ -3,6 +3,7 @@ import { RefreshCw, AlertTriangle, CheckCircle, HelpCircle } from 'lucide-react'
 
 import { useSidebar } from '@/components/animate-ui/components/radix/sidebar'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { formatVersion, resolveCurrentAppVersion } from '@/lib/version'
 import { apiClient } from '@/services/api/client'
 import { githubService } from '@/services/github'
 import type { VersionStatus } from '@/types/github'
@@ -11,7 +12,7 @@ import type { VersionStatus } from '@/types/github'
 import packageJson from '../../package.json'
 
 // Current versions
-const CURRENT_APP_VERSION = packageJson.version
+const CURRENT_APP_VERSION = resolveCurrentAppVersion(packageJson.version)
 
 interface VersionStatusProps {
   className?: string
@@ -105,11 +106,6 @@ export function VersionStatus({ className }: VersionStatusProps) {
       case 'unknown':
         return <HelpCircle className="size-4 text-gray-500" />
     }
-  }
-
-  const formatVersion = (version: string | null) => {
-    if (!version) return 'Unknown'
-    return version.startsWith('v') ? version : `v${version}`
   }
 
   const isPreRelease = !versionInfo?.app.latest && !versionInfo?.api.latest

--- a/packages/hermes-app/src/lib/__tests__/version.test.ts
+++ b/packages/hermes-app/src/lib/__tests__/version.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatVersion, isComparableVersion, resolveCurrentAppVersion } from '@/lib/version'
+
+describe('version utilities', () => {
+  it('uses CI build version before package version', () => {
+    expect(resolveCurrentAppVersion('0.4.0', 'v0.4.0')).toBe('v0.4.0')
+  })
+
+  it('falls back to package version when build version is missing', () => {
+    expect(resolveCurrentAppVersion('0.4.0', undefined)).toBe('0.4.0')
+    expect(resolveCurrentAppVersion('0.4.0', '   ')).toBe('0.4.0')
+  })
+
+  it('formats semantic versions with a v prefix', () => {
+    expect(formatVersion('0.4.0')).toBe('v0.4.0')
+    expect(formatVersion('v0.4.0')).toBe('v0.4.0')
+  })
+
+  it('leaves non-semver build labels unchanged', () => {
+    expect(formatVersion('develop-abc123')).toBe('develop-abc123')
+  })
+
+  it('identifies versions that can be compared against release tags', () => {
+    expect(isComparableVersion('0.4.0')).toBe(true)
+    expect(isComparableVersion('v0.4.0')).toBe(true)
+    expect(isComparableVersion('develop-abc123')).toBe(false)
+  })
+})

--- a/packages/hermes-app/src/lib/version.ts
+++ b/packages/hermes-app/src/lib/version.ts
@@ -1,0 +1,20 @@
+const SEMVER_VERSION_PATTERN = /^v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/
+
+export function resolveCurrentAppVersion(
+  packageVersion: string,
+  buildVersion = import.meta.env.VITE_HERMES_BUILD_VERSION
+): string {
+  const normalizedBuildVersion = buildVersion?.trim()
+  return normalizedBuildVersion || packageVersion
+}
+
+export function formatVersion(version: string | null): string {
+  if (!version) return 'Unknown'
+  if (version.startsWith('v')) return version
+  if (!SEMVER_VERSION_PATTERN.test(version)) return version
+  return `v${version}`
+}
+
+export function isComparableVersion(version: string): boolean {
+  return SEMVER_VERSION_PATTERN.test(version)
+}

--- a/packages/hermes-app/src/services/github.ts
+++ b/packages/hermes-app/src/services/github.ts
@@ -1,6 +1,7 @@
 // GitHub API Service for version checking
 
 import type { VersionInfo } from '@/types/github'
+import { isComparableVersion } from '@/lib/version'
 
 // GitHub Tag API response types
 interface GitHubTagRef {
@@ -103,7 +104,7 @@ class GitHubService {
   }
 
   compareVersions(currentVersion: string, latestVersion: string | null): 'up-to-date' | 'outdated' | 'unknown' {
-    if (!latestVersion) {
+    if (!latestVersion || !isComparableVersion(currentVersion) || !isComparableVersion(latestVersion)) {
       return 'unknown'
     }
 


### PR DESCRIPTION
## Summary
- inject CI build version metadata into app and API Docker builds
- make the app version display prefer CI metadata with package fallback
- make API health prefer HERMES_BUILD_VERSION with existing metadata fallback
- avoid semver update comparisons for non-semver build labels like develop SHAs

## Validation
- pnpm --filter hermes-app type-check
- pnpm --filter hermes-app lint
- pnpm --filter hermes-app test src/lib/__tests__/version.test.ts
- uv run pytest tests/test_api/test_health.py
- YAML parse for changed workflows