### PR TITLE
test: cover critical download paths and reduce queue duplication

### DIFF
--- a/packages/hermes-api/app/api/v1/endpoints/downloads.py
+++ b/packages/hermes-api/app/api/v1/endpoints/downloads.py
@@ -146,14 +146,20 @@ async def get_download_status(
         if download.status == "downloading":
             redis_progress = await redis_progress_service.get_progress(download_id)
             if redis_progress:
+                progress_source = redis_progress.get("progress")
+                if not isinstance(progress_source, dict):
+                    progress_source = redis_progress
+
                 # Use Redis data for active downloads
                 progress_info = DownloadProgress(
-                    percentage=redis_progress.get("percentage", 0.0),
-                    status=redis_progress.get("status", "downloading"),
-                    downloaded_bytes=redis_progress.get("downloaded_bytes"),
-                    total_bytes=redis_progress.get("total_bytes"),
-                    speed=redis_progress.get("speed"),
-                    eta=redis_progress.get("eta"),
+                    percentage=progress_source.get("percentage", 0.0),
+                    status=progress_source.get(
+                        "status", redis_progress.get("status", "downloading")
+                    ),
+                    downloaded_bytes=progress_source.get("downloaded_bytes"),
+                    total_bytes=progress_source.get("total_bytes"),
+                    speed=progress_source.get("speed"),
+                    eta=progress_source.get("eta"),
                 )
 
         # Fall back to database if not in Redis or not downloading

--- a/packages/hermes-api/app/api/v1/endpoints/downloads.py
+++ b/packages/hermes-api/app/api/v1/endpoints/downloads.py
@@ -21,6 +21,7 @@ from app.models.pydantic.download import (
 )
 from app.services.redis_progress import redis_progress_service
 from app.tasks.download_tasks import batch_download_task, download_video_task
+from app.utils.download_progress import progress_fields_from_payload
 
 router = APIRouter()
 logger = get_logger(__name__)
@@ -146,20 +147,11 @@ async def get_download_status(
         if download.status == "downloading":
             redis_progress = await redis_progress_service.get_progress(download_id)
             if redis_progress:
-                progress_source = redis_progress.get("progress")
-                if not isinstance(progress_source, dict):
-                    progress_source = redis_progress
-
                 # Use Redis data for active downloads
                 progress_info = DownloadProgress(
-                    percentage=progress_source.get("percentage", 0.0),
-                    status=progress_source.get(
-                        "status", redis_progress.get("status", "downloading")
-                    ),
-                    downloaded_bytes=progress_source.get("downloaded_bytes"),
-                    total_bytes=progress_source.get("total_bytes"),
-                    speed=progress_source.get("speed"),
-                    eta=progress_source.get("eta"),
+                    **progress_fields_from_payload(
+                        redis_progress, fallback_status="downloading"
+                    )
                 )
 
         # Fall back to database if not in Redis or not downloading

--- a/packages/hermes-api/app/api/v1/endpoints/stats.py
+++ b/packages/hermes-api/app/api/v1/endpoints/stats.py
@@ -2,7 +2,7 @@
 API statistics endpoint.
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy import select
@@ -13,6 +13,7 @@ from app.core.security import ApiKeyPermission, AuthPrincipal, require_api_permi
 from app.db.models import DownloadHistory
 from app.db.session import get_database_session
 from app.models.pydantic.stats import ApiStatistics, ErrorBreakdown, ExtractorStats
+from app.utils.time_periods import get_period_delta
 
 router = APIRouter(prefix="/stats", tags=["statistics"])
 logger = get_logger(__name__)
@@ -46,13 +47,7 @@ async def get_api_statistics(
     try:
         # Calculate time range
         now = datetime.now(timezone.utc)
-        period_map = {
-            "day": timedelta(days=1),
-            "week": timedelta(days=7),
-            "month": timedelta(days=30),
-            "year": timedelta(days=365),
-        }
-        start_time = now - period_map.get(period, timedelta(days=7))
+        start_time = now - get_period_delta(period)
 
         # Get all history records in period
         query = select(DownloadHistory).where(

--- a/packages/hermes-api/app/api/v1/endpoints/timeline.py
+++ b/packages/hermes-api/app/api/v1/endpoints/timeline.py
@@ -3,7 +3,7 @@ Timeline analytics endpoint for charts and data visualization.
 """
 
 from datetime import date as date_type
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -15,6 +15,7 @@ from app.core.security import ApiKeyPermission, AuthPrincipal, require_api_permi
 from app.db.models import DownloadHistory as DownloadHistoryModel
 from app.db.session import get_database_session
 from app.models.pydantic.history import DailyStats, TimelineSummary
+from app.utils.time_periods import get_period_delta
 
 router = APIRouter(prefix="/timeline", tags=["timeline"])
 logger = get_logger(__name__)
@@ -63,13 +64,7 @@ async def get_timeline_stats(
         else:
             # Use period-based calculation
             now = datetime.now(timezone.utc)
-            period_map = {
-                "day": timedelta(days=1),
-                "week": timedelta(days=7),
-                "month": timedelta(days=30),
-                "year": timedelta(days=365),
-            }
-            start_datetime = now - period_map.get(period, timedelta(days=7))
+            start_datetime = now - get_period_delta(period)
             date_filters = [DownloadHistoryModel.completed_at >= start_datetime]
 
         # Build additional filters

--- a/packages/hermes-api/app/services/yt_dlp_service.py
+++ b/packages/hermes-api/app/services/yt_dlp_service.py
@@ -11,6 +11,7 @@ import yt_dlp
 from yt_dlp.utils import DownloadError, ExtractorError
 
 from app.core.logging import get_logger
+from app.utils.media import VIDEO_EXTENSIONS
 
 logger = get_logger(__name__)
 
@@ -122,16 +123,7 @@ class YTDLPService:
                                 base_name = base_name.replace(".%(ext)s", "")
 
                             # Look for the actual downloaded file with common extensions
-                            for ext in [
-                                ".mp4",
-                                ".webm",
-                                ".mkv",
-                                ".avi",
-                                ".mov",
-                                ".flv",
-                                ".3gp",
-                                ".m4v",
-                            ]:
+                            for ext in VIDEO_EXTENSIONS:
                                 potential_path = os.path.join(
                                     directory, base_name + ext
                                 )

--- a/packages/hermes-api/app/tasks/cleanup_tasks.py
+++ b/packages/hermes-api/app/tasks/cleanup_tasks.py
@@ -20,26 +20,20 @@ from app.tasks.celery_app import celery_app
 logger = get_logger(__name__)
 
 
-async def _get_repositories_for_task():
-    """Get repository instances for background tasks with proper session management."""
-    async with async_session_maker() as session:
-        return {
-            "downloads": DownloadRepository(session),
-            "download_files": DownloadFileRepository(session),
-            "token_blacklist": TokenBlacklistRepository(session),
-            "history": DownloadHistoryRepository(session),
-        }
+def _get_cleanup_repositories(session):
+    """Create cleanup task repositories for an active database session."""
+    return {
+        "downloads": DownloadRepository(session),
+        "download_files": DownloadFileRepository(session),
+        "token_blacklist": TokenBlacklistRepository(session),
+        "history": DownloadHistoryRepository(session),
+    }
 
 
 async def _get_old_downloads(days: int = 30) -> List[Dict[str, Any]]:
     """Get downloads older than specified days."""
     async with async_session_maker() as session:
-        repos = {
-            "downloads": DownloadRepository(session),
-            "download_files": DownloadFileRepository(session),
-            "token_blacklist": TokenBlacklistRepository(session),
-            "history": DownloadHistoryRepository(session),
-        }
+        repos = _get_cleanup_repositories(session)
         cutoff_date = datetime.now(timezone.utc) - timedelta(days=days)
 
         # Get downloads that are completed/failed and older than cutoff
@@ -59,12 +53,7 @@ async def _cleanup_download_files(download_ids: List[str]) -> Dict[str, Any]:
     failed_files = []
 
     async with async_session_maker() as session:
-        repos = {
-            "downloads": DownloadRepository(session),
-            "download_files": DownloadFileRepository(session),
-            "token_blacklist": TokenBlacklistRepository(session),
-            "history": DownloadHistoryRepository(session),
-        }
+        repos = _get_cleanup_repositories(session)
 
         for download_id in download_ids:
             try:
@@ -167,12 +156,7 @@ async def _cleanup_old_downloads_async(
             # Just count what would be deleted
             total_files = 0
             async with async_session_maker() as session:
-                repos = {
-                    "downloads": DownloadRepository(session),
-                    "download_files": DownloadFileRepository(session),
-                    "token_blacklist": TokenBlacklistRepository(session),
-                    "history": DownloadHistoryRepository(session),
-                }
+                repos = _get_cleanup_repositories(session)
 
                 for download_id in download_ids:
                     files = await repos["download_files"].get_by_download_id(
@@ -193,12 +177,7 @@ async def _cleanup_old_downloads_async(
         # Delete download records from database
         deleted_downloads = 0
         async with async_session_maker() as session:
-            repos = {
-                "downloads": DownloadRepository(session),
-                "download_files": DownloadFileRepository(session),
-                "token_blacklist": TokenBlacklistRepository(session),
-                "history": DownloadHistoryRepository(session),
-            }
+            repos = _get_cleanup_repositories(session)
 
             for download_id in download_ids:
                 try:
@@ -341,12 +320,7 @@ async def _cleanup_expired_tokens_async(dry_run: bool = False) -> Dict[str, Any]
         now = datetime.now(timezone.utc)
 
         async with async_session_maker() as session:
-            repos = {
-                "downloads": DownloadRepository(session),
-                "download_files": DownloadFileRepository(session),
-                "token_blacklist": TokenBlacklistRepository(session),
-                "history": DownloadHistoryRepository(session),
-            }
+            repos = _get_cleanup_repositories(session)
 
             if dry_run:
                 # Count expired tokens without deleting

--- a/packages/hermes-api/app/tasks/download_tasks.py
+++ b/packages/hermes-api/app/tasks/download_tasks.py
@@ -19,6 +19,10 @@ from app.db.repositories import (
 from app.services.redis_progress import redis_progress_service
 from app.services.yt_dlp_service import YTDLPService
 from app.tasks.celery_app import celery_app
+from app.utils.download_progress import (
+    build_download_progress_payload,
+    build_progress_object,
+)
 
 logger = get_logger(__name__)
 yt_service = YTDLPService()
@@ -76,22 +80,17 @@ async def _publish_sse_progress(
     """
     # Structure to match DownloadStatus schema
     # Note: download_id is added by publish_download_progress
-    sse_data = {
-        "status": status,
-        "message": f"Downloading: {progress:.1f}%" if progress else "Downloading...",
-        "progress": {
-            "percentage": progress,
-            "status": status,
-            "downloaded_bytes": downloaded_bytes,
-            "total_bytes": total_bytes,
-            "speed": download_speed,
-            "eta": eta,
-        },
-    }
-
-    # Include result object if provided (for video metadata)
-    if result:
-        sse_data["result"] = result
+    sse_data = build_download_progress_payload(
+        status=status,
+        message=f"Downloading: {progress:.1f}%" if progress else "Downloading...",
+        progress=progress,
+        downloaded_bytes=downloaded_bytes,
+        total_bytes=total_bytes,
+        download_speed=download_speed,
+        eta=eta,
+        result=result,
+        include_progress=True,
+    )
 
     # Debug logging
     logger.info(
@@ -146,23 +145,23 @@ async def _update_download_status(
     # Optionally publish SSE (disabled during progress updates for frequency control)
     if publish_sse:
         # Structure to match DownloadStatus schema with nested progress object
-        progress_data = {
-            "status": status,
-            "error_message": error_message,
+        progress_data = build_download_progress_payload(
+            status=status,
+            error_message=error_message,
             **kwargs,
-        }
+        )
 
         # Add nested progress object (matching _publish_sse_progress structure)
         # Always include progress for active downloads to prevent frontend state loss
         if progress is not None or downloaded_bytes is not None:
-            progress_data["progress"] = {
-                "percentage": progress,
-                "status": status,
-                "downloaded_bytes": downloaded_bytes,
-                "total_bytes": total_bytes,
-                "speed": download_speed,
-                "eta": eta,
-            }
+            progress_data["progress"] = build_progress_object(
+                status=status,
+                progress=progress,
+                downloaded_bytes=downloaded_bytes,
+                total_bytes=total_bytes,
+                download_speed=download_speed,
+                eta=eta,
+            )
         elif status in ("downloading", "processing"):
             # For active downloads without new progress data, fetch current progress from DB
             # to prevent SSE events from wiping out frontend progress state
@@ -170,14 +169,14 @@ async def _update_download_status(
                 download_repo = DownloadRepository(session)
                 download = await download_repo.get_by_id(download_id)
                 if download and download.progress is not None:
-                    progress_data["progress"] = {
-                        "percentage": download.progress,
-                        "status": status,
-                        "downloaded_bytes": download.downloaded_bytes,
-                        "total_bytes": download.total_bytes,
-                        "speed": download.download_speed,
-                        "eta": download.eta,
-                    }
+                    progress_data["progress"] = build_progress_object(
+                        status=status,
+                        progress=download.progress,
+                        downloaded_bytes=download.downloaded_bytes,
+                        total_bytes=download.total_bytes,
+                        download_speed=download.download_speed,
+                        eta=download.eta,
+                    )
 
         # Debug logging to trace SSE events
         logger.info(
@@ -371,17 +370,17 @@ async def _download_video_task(
                     # Prepare progress data matching DownloadStatus schema
                     progress_data = {
                         "download_id": download_id,
-                        "status": "downloading",
-                        "message": f"Downloading: {percentage:.1f}%",
-                        "progress": {
-                            "percentage": percentage,
-                            "status": "downloading",
-                            "downloaded_bytes": downloaded_int,
-                            "total_bytes": total_int,
-                            "speed": speed_float,
-                            "eta": eta_float,
-                        },
-                        "result": result_data,  # Include video metadata
+                        **build_download_progress_payload(
+                            status="downloading",
+                            message=f"Downloading: {percentage:.1f}%",
+                            progress=percentage,
+                            downloaded_bytes=downloaded_int,
+                            total_bytes=total_int,
+                            download_speed=speed_float,
+                            eta=eta_float,
+                            result=result_data,
+                            include_progress=True,
+                        ),
                     }
 
                     # ============================================================

--- a/packages/hermes-api/app/tasks/download_tasks.py
+++ b/packages/hermes-api/app/tasks/download_tasks.py
@@ -23,6 +23,7 @@ from app.utils.download_progress import (
     build_download_progress_payload,
     build_progress_object,
 )
+from app.utils.media import VIDEO_EXTENSIONS
 
 logger = get_logger(__name__)
 yt_service = YTDLPService()
@@ -467,23 +468,12 @@ async def _download_video_task(
 
         if result_path and os.path.exists(result_path):
             # Ensure the file has a proper extension
-            if not result_path.lower().endswith(
-                (".mp4", ".webm", ".mkv", ".avi", ".mov", ".flv", ".3gp", ".m4v")
-            ):
+            if not result_path.lower().endswith(VIDEO_EXTENSIONS):
                 # Try to find the correct file with extension
                 directory = os.path.dirname(result_path)
                 base_name = os.path.basename(result_path)
 
-                for ext in [
-                    ".mp4",
-                    ".webm",
-                    ".mkv",
-                    ".avi",
-                    ".mov",
-                    ".flv",
-                    ".3gp",
-                    ".m4v",
-                ]:
+                for ext in VIDEO_EXTENSIONS:
                     potential_path = os.path.join(directory, base_name + ext)
                     if os.path.exists(potential_path):
                         result_path = potential_path

--- a/packages/hermes-api/app/tasks/download_tasks.py
+++ b/packages/hermes-api/app/tasks/download_tasks.py
@@ -83,7 +83,11 @@ async def _publish_sse_progress(
     # Note: download_id is added by publish_download_progress
     sse_data = build_download_progress_payload(
         status=status,
-        message=f"Downloading: {progress:.1f}%" if progress else "Downloading...",
+        message=(
+            f"Downloading: {progress:.1f}%"
+            if progress is not None
+            else "Downloading..."
+        ),
         progress=progress,
         downloaded_bytes=downloaded_bytes,
         total_bytes=total_bytes,

--- a/packages/hermes-api/app/utils/download_progress.py
+++ b/packages/hermes-api/app/utils/download_progress.py
@@ -1,0 +1,85 @@
+"""Helpers for shaping download progress data across API, tasks, and SSE."""
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def build_progress_object(
+    *,
+    status: str,
+    progress: float | None = None,
+    downloaded_bytes: int | None = None,
+    total_bytes: int | None = None,
+    download_speed: float | None = None,
+    eta: float | None = None,
+) -> dict[str, Any]:
+    """Build the nested progress object used by DownloadStatus and SSE payloads."""
+    return {
+        "percentage": progress,
+        "status": status,
+        "downloaded_bytes": downloaded_bytes,
+        "total_bytes": total_bytes,
+        "speed": download_speed,
+        "eta": eta,
+    }
+
+
+def build_download_progress_payload(
+    *,
+    status: str,
+    progress: float | None = None,
+    downloaded_bytes: int | None = None,
+    total_bytes: int | None = None,
+    download_speed: float | None = None,
+    eta: float | None = None,
+    message: str | None = None,
+    result: dict[str, Any] | None = None,
+    include_progress: bool = False,
+    **extra: Any,
+) -> dict[str, Any]:
+    """Build a download progress payload with one canonical nested shape."""
+    payload = {
+        "status": status,
+        **extra,
+    }
+
+    if message is not None:
+        payload["message"] = message
+
+    if include_progress or progress is not None or downloaded_bytes is not None:
+        payload["progress"] = build_progress_object(
+            status=status,
+            progress=progress,
+            downloaded_bytes=downloaded_bytes,
+            total_bytes=total_bytes,
+            download_speed=download_speed,
+            eta=eta,
+        )
+
+    if result:
+        payload["result"] = result
+
+    return payload
+
+
+def progress_source_from_payload(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Read nested progress payloads while retaining compatibility with flat data."""
+    progress_source = payload.get("progress")
+    if isinstance(progress_source, Mapping):
+        return progress_source
+    return payload
+
+
+def progress_fields_from_payload(
+    payload: Mapping[str, Any], *, fallback_status: str
+) -> dict[str, Any]:
+    """Convert a Redis progress payload into DownloadProgress constructor kwargs."""
+    progress_source = progress_source_from_payload(payload)
+    return {
+        "percentage": progress_source.get("percentage", 0.0),
+        "status": progress_source.get("status", payload.get("status", fallback_status)),
+        "downloaded_bytes": progress_source.get("downloaded_bytes"),
+        "total_bytes": progress_source.get("total_bytes"),
+        "speed": progress_source.get("speed"),
+        "eta": progress_source.get("eta"),
+    }

--- a/packages/hermes-api/app/utils/media.py
+++ b/packages/hermes-api/app/utils/media.py
@@ -1,0 +1,3 @@
+"""Media-related constants shared by download services and tasks."""
+
+VIDEO_EXTENSIONS = (".mp4", ".webm", ".mkv", ".avi", ".mov", ".flv", ".3gp", ".m4v")

--- a/packages/hermes-api/app/utils/time_periods.py
+++ b/packages/hermes-api/app/utils/time_periods.py
@@ -1,0 +1,16 @@
+"""Shared time period helpers for analytics endpoints."""
+
+from datetime import timedelta
+
+PERIOD_DELTAS = {
+    "day": timedelta(days=1),
+    "week": timedelta(days=7),
+    "month": timedelta(days=30),
+    "year": timedelta(days=365),
+}
+DEFAULT_PERIOD_DELTA = PERIOD_DELTAS["week"]
+
+
+def get_period_delta(period: str) -> timedelta:
+    """Return the configured period delta, defaulting to one week."""
+    return PERIOD_DELTAS.get(period, DEFAULT_PERIOD_DELTA)

--- a/packages/hermes-api/tests/test_api/test_downloads.py
+++ b/packages/hermes-api/tests/test_api/test_downloads.py
@@ -1,0 +1,188 @@
+"""Tests for download endpoint orchestration.
+
+External work queues and Redis are mocked; these tests cover API-owned request
+handling, persistence, response shaping, and state transitions.
+"""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.repositories import DownloadRepository
+
+
+class TestDownloadEndpoints:
+    """Download endpoint behavior that belongs to Hermes."""
+
+    @pytest.mark.asyncio
+    async def test_start_download_creates_record_and_queues_task(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        with patch(
+            "app.api.v1.endpoints.downloads.download_video_task.apply_async"
+        ) as apply_async:
+            response = await client.post(
+                "/api/v1/download/",
+                json={
+                    "url": "https://example.test/watch",
+                    "format": "bestvideo+bestaudio",
+                    "outputDirectory": "/downloads/custom",
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "pending"
+        assert data["message"] == "Download queued successfully"
+
+        download = await DownloadRepository(db_session).get_by_id(data["downloadId"])
+        assert download is not None
+        assert download.url == "https://example.test/watch"
+        assert download.format_spec == "bestvideo+bestaudio"
+        assert download.status == "pending"
+
+        apply_async.assert_called_once_with(
+            kwargs={
+                "download_id": data["downloadId"],
+                "url": "https://example.test/watch",
+                "format_spec": "bestvideo+bestaudio",
+                "output_path": "/downloads/custom",
+            },
+            queue="hermes.downloads",
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_download_status_uses_nested_redis_progress_from_task(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        download = await DownloadRepository(db_session).create(
+            url="https://example.test/watch",
+            status="downloading",
+            title="Redis Video",
+            progress=12.0,
+            downloaded_bytes=120,
+            total_bytes=1000,
+        )
+
+        redis_payload = {
+            "status": "downloading",
+            "message": "Downloading: 42.5%",
+            "progress": {
+                "percentage": 42.5,
+                "status": "downloading",
+                "downloaded_bytes": 425,
+                "total_bytes": 1000,
+                "speed": 2048.0,
+                "eta": 12.0,
+            },
+        }
+
+        with patch(
+            "app.api.v1.endpoints.downloads.redis_progress_service.get_progress",
+            new=AsyncMock(return_value=redis_payload),
+        ) as get_progress:
+            response = await client.get(f"/api/v1/download/{download.id}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["downloadId"] == download.id
+        assert data["status"] == "downloading"
+        assert data["progress"] == {
+            "percentage": 42.5,
+            "status": "downloading",
+            "downloadedBytes": 425,
+            "totalBytes": 1000,
+            "speed": 2048.0,
+            "eta": 12.0,
+        }
+        assert data["result"]["title"] == "Redis Video"
+        get_progress.assert_awaited_once_with(download.id)
+
+    @pytest.mark.asyncio
+    async def test_cancel_download_updates_cancellable_status(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        download = await DownloadRepository(db_session).create(
+            url="https://example.test/watch",
+            status="pending",
+        )
+
+        response = await client.post(f"/api/v1/download/{download.id}/cancel")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data == {
+            "downloadId": download.id,
+            "cancelled": True,
+            "message": "Download cancelled successfully",
+        }
+
+        await db_session.refresh(download)
+        assert download.status == "cancelled"
+        assert download.error_message == "Cancelled by user"
+
+    @pytest.mark.asyncio
+    async def test_cancel_download_rejects_terminal_status(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        download = await DownloadRepository(db_session).create(
+            url="https://example.test/watch",
+            status="completed",
+        )
+
+        response = await client.post(f"/api/v1/download/{download.id}/cancel")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "downloadId": download.id,
+            "cancelled": False,
+            "message": "Cannot cancel completed download",
+        }
+
+        await db_session.refresh(download)
+        assert download.status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_start_batch_download_creates_records_and_schedules_batch(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        batch_task = Mock()
+
+        with patch("app.api.v1.endpoints.downloads.batch_download_task", batch_task):
+            response = await client.post(
+                "/api/v1/download/batch",
+                json={
+                    "urls": [
+                        "https://example.test/one",
+                        "https://example.test/two",
+                    ],
+                    "format": "best",
+                    "outputDirectory": "/downloads/batch",
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["batchId"] == "batch_2_urls"
+        assert data["totalDownloads"] == 2
+        assert data["status"] == "queued"
+        assert len(data["downloads"]) == 2
+
+        repo = DownloadRepository(db_session)
+        downloads = [
+            await repo.get_by_id(download_id) for download_id in data["downloads"]
+        ]
+        assert [download.url for download in downloads] == [
+            "https://example.test/one",
+            "https://example.test/two",
+        ]
+        assert [download.status for download in downloads] == ["pending", "pending"]
+
+        batch_task.assert_called_once_with(
+            data["downloads"],
+            ["https://example.test/one", "https://example.test/two"],
+            "best",
+            "/downloads/batch",
+        )

--- a/packages/hermes-api/tests/test_services/test_yt_dlp_service.py
+++ b/packages/hermes-api/tests/test_services/test_yt_dlp_service.py
@@ -83,3 +83,79 @@ async def test_extract_info_uses_yt_dlp_defaults_when_node_is_unavailable():
     assert result["title"] == "Test Video"
     assert "js_runtimes" not in FakeYoutubeDL.calls[0]
     assert "remote_components" not in FakeYoutubeDL.calls[0]
+
+
+@pytest.mark.asyncio
+async def test_download_video_finds_file_when_prepared_template_keeps_ext_placeholder(
+    tmp_path,
+):
+    class FakeTemplateYoutubeDL:
+        def __init__(self, opts):
+            self.opts = opts
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+        def extract_info(self, url, download=False):
+            return {"id": "test-video", "title": "Test Video"}
+
+        def prepare_filename(self, info):
+            return self.opts["outtmpl"]
+
+    output_path = tmp_path / "test-video.%(ext)s"
+    downloaded_path = tmp_path / "test-video.webm"
+    downloaded_path.write_bytes(b"video")
+
+    service = YTDLPService()
+    with patch("app.services.yt_dlp_service.yt_dlp.YoutubeDL", FakeTemplateYoutubeDL):
+        result_path = await service.download_video(
+            "https://example.com/video",
+            str(output_path),
+        )
+
+    assert result_path == str(downloaded_path)
+
+
+@pytest.mark.asyncio
+async def test_download_video_uses_selected_format_extension_when_common_lookup_fails(
+    tmp_path,
+):
+    class FakeFormatYoutubeDL:
+        def __init__(self, opts):
+            self.opts = opts
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+        def extract_info(self, url, download=False):
+            return {
+                "id": "audio-video",
+                "title": "Audio Video",
+                "formats": [
+                    {"format_id": "18", "ext": "mp4"},
+                    {"format_id": "140", "ext": "m4a"},
+                ],
+            }
+
+        def prepare_filename(self, info):
+            return self.opts["outtmpl"]
+
+    output_path = tmp_path / "audio-video.%(ext)s"
+    downloaded_path = tmp_path / "audio-video.m4a"
+    downloaded_path.write_bytes(b"audio")
+
+    service = YTDLPService()
+    with patch("app.services.yt_dlp_service.yt_dlp.YoutubeDL", FakeFormatYoutubeDL):
+        result_path = await service.download_video(
+            "https://example.com/video",
+            str(output_path),
+            format_spec="140",
+        )
+
+    assert result_path == str(downloaded_path)

--- a/packages/hermes-api/tests/test_tasks/test_download_tasks.py
+++ b/packages/hermes-api/tests/test_tasks/test_download_tasks.py
@@ -1,0 +1,502 @@
+"""Tests for download task orchestration.
+
+These tests mock external boundaries (yt-dlp, Redis, webhooks, and database
+writes) so they exercise Hermes' own task state machine and data shaping.
+"""
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, Mock, call, patch
+
+import pytest
+
+from app.tasks import download_tasks
+
+
+def test_sanitize_filename_removes_invalid_characters_and_normalizes_spaces():
+    assert (
+        download_tasks.sanitize_filename(' My <Great>: "Video" / Part 1?.mp4 ')
+        == "My_Great_Video_Part_1.mp4"
+    )
+
+
+def test_sanitize_filename_returns_default_for_empty_result():
+    assert download_tasks.sanitize_filename(' <>:"/\\|?* .. ') == "video"
+
+
+def test_sanitize_filename_limits_very_long_names():
+    assert len(download_tasks.sanitize_filename("a" * 250)) == 200
+
+
+@pytest.mark.asyncio
+async def test_publish_sse_progress_shapes_download_status_payload():
+    mock_progress_service = AsyncMock()
+
+    with patch.object(download_tasks, "redis_progress_service", mock_progress_service):
+        await download_tasks._publish_sse_progress(
+            download_id="download-123",
+            status="downloading",
+            progress=37.5,
+            downloaded_bytes=375,
+            total_bytes=1000,
+            download_speed=42.0,
+            eta=9.0,
+            result={"title": "Example"},
+        )
+
+    mock_progress_service.publish_download_progress.assert_awaited_once_with(
+        download_id="download-123",
+        progress_data={
+            "status": "downloading",
+            "message": "Downloading: 37.5%",
+            "progress": {
+                "percentage": 37.5,
+                "status": "downloading",
+                "downloaded_bytes": 375,
+                "total_bytes": 1000,
+                "speed": 42.0,
+                "eta": 9.0,
+            },
+            "result": {"title": "Example"},
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_download_status_publishes_cached_db_progress_for_active_status(
+    db_session,
+):
+    from app.db.repositories import DownloadRepository
+
+    repo = DownloadRepository(db_session)
+    download = await repo.create(
+        url="https://example.test/watch",
+        status="downloading",
+    )
+    await repo.update_status(
+        download.id,
+        "downloading",
+        progress=33.0,
+        downloaded_bytes=330,
+        total_bytes=1000,
+        download_speed=2048.0,
+        eta=18.0,
+    )
+
+    redis_progress_service = AsyncMock()
+
+    with patch.object(download_tasks, "redis_progress_service", redis_progress_service):
+        await download_tasks._update_download_status(download.id, "processing")
+
+    redis_progress_service.publish_download_progress.assert_awaited_once_with(
+        download_id=download.id,
+        progress_data={
+            "status": "processing",
+            "error_message": None,
+            "progress": {
+                "percentage": 33.0,
+                "status": "processing",
+                "downloaded_bytes": 330,
+                "total_bytes": 1000,
+                "speed": 2048.0,
+                "eta": 18.0,
+            },
+        },
+    )
+    redis_progress_service.publish_queue_update.assert_awaited_once_with(
+        action="status_changed",
+        download_id=download.id,
+        data={"status": "processing"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_download_video_task_success_updates_metadata_and_cleans_up(tmp_path):
+    download_file = tmp_path / "Dangerous_Title.mp4"
+    yt_service = AsyncMock()
+    yt_service.extract_info.return_value = {
+        "title": 'Dangerous: "Title"?',
+        "thumbnail": "https://example.test/thumb.jpg",
+        "extractor": "ExampleSite",
+        "description": "An example video",
+        "duration": 123,
+    }
+
+    async def fake_download_video(
+        url, output_path, format_spec, progress_callback=None, **kwargs
+    ):
+        assert url == "https://example.test/watch"
+        assert output_path == os.path.join(str(tmp_path), "Dangerous_Title.%(ext)s")
+        assert format_spec == "bestvideo+bestaudio"
+        assert kwargs == {"merge_output_format": "mp4"}
+        download_file.write_bytes(b"video")
+        return str(download_file)
+
+    yt_service.download_video.side_effect = fake_download_video
+
+    update_status = AsyncMock()
+    create_history = AsyncMock()
+    trigger_webhooks = AsyncMock()
+    redis_progress_service = AsyncMock()
+    redis_progress_service.revoke_user_sse_tokens.return_value = 2
+
+    with (
+        patch.object(download_tasks, "yt_service", yt_service),
+        patch.object(download_tasks, "_update_download_status", update_status),
+        patch.object(download_tasks, "_create_download_history", create_history),
+        patch.object(download_tasks, "_trigger_webhooks", trigger_webhooks),
+        patch.object(download_tasks, "redis_progress_service", redis_progress_service),
+    ):
+        result = await download_tasks._download_video_task(
+            download_id="download-123",
+            url="https://example.test/watch",
+            format_spec="bestvideo+bestaudio",
+            output_path=str(tmp_path),
+            merge_output_format="mp4",
+        )
+
+    assert result == {
+        "success": True,
+        "download_id": "download-123",
+        "file_path": str(download_file),
+        "file_size": 5,
+    }
+    yt_service.extract_info.assert_awaited_once_with(
+        "https://example.test/watch", download=False
+    )
+    yt_service.download_video.assert_awaited_once()
+
+    initial_status_call = update_status.await_args_list[0]
+    assert initial_status_call.args == ("download-123", "downloading")
+    assert initial_status_call.kwargs["started_at"].tzinfo is not None
+    assert update_status.await_args_list[1] == call(
+        "download-123",
+        "downloading",
+        title='Dangerous: "Title"?',
+        thumbnail_url="https://example.test/thumb.jpg",
+        extractor="ExampleSite",
+        description="An example video",
+        duration=123,
+        result={
+            "url": "https://example.test/watch",
+            "title": 'Dangerous: "Title"?',
+            "thumbnail_url": "https://example.test/thumb.jpg",
+            "extractor": "ExampleSite",
+            "description": "An example video",
+            "duration": 123,
+        },
+    )
+    completed_call = update_status.await_args_list[2]
+    assert completed_call.args == ("download-123", "completed")
+    assert completed_call.kwargs["progress"] == 100.0
+    assert completed_call.kwargs["file_size"] == 5
+    assert completed_call.kwargs["output_path"] == str(download_file)
+    assert completed_call.kwargs["result"] == {
+        "url": "https://example.test/watch",
+        "title": 'Dangerous: "Title"?',
+        "file_size": 5,
+        "duration": 123,
+        "thumbnail_url": "https://example.test/thumb.jpg",
+        "extractor": "ExampleSite",
+        "description": "An example video",
+    }
+
+    create_history.assert_awaited_once()
+    assert create_history.await_args.kwargs["download_id"] == "download-123"
+    assert create_history.await_args.kwargs["status"] == "completed"
+    assert create_history.await_args.kwargs["file_size"] == 5
+
+    assert trigger_webhooks.await_args_list[0] == call(
+        "download_started", "download-123", {"url": "https://example.test/watch"}
+    )
+    assert trigger_webhooks.await_args_list[1] == call(
+        "download_completed",
+        "download-123",
+        {
+            "url": "https://example.test/watch",
+            "file_path": str(download_file),
+            "file_size": 5,
+        },
+    )
+    redis_progress_service.publish_stats_update.assert_awaited_once()
+    redis_progress_service.delete_progress.assert_awaited_once_with("download-123")
+    redis_progress_service.revoke_user_sse_tokens.assert_awaited_once_with(
+        user_id="*", scope_prefix="download:download-123"
+    )
+
+
+@pytest.mark.asyncio
+async def test_download_video_task_extract_failure_marks_failed_and_cleans_up():
+    yt_service = AsyncMock()
+    yt_service.extract_info.return_value = None
+
+    update_status = AsyncMock()
+    create_history = AsyncMock()
+    trigger_webhooks = AsyncMock()
+    redis_progress_service = AsyncMock()
+    redis_progress_service.revoke_user_sse_tokens.return_value = 0
+
+    with (
+        patch.object(download_tasks, "yt_service", yt_service),
+        patch.object(download_tasks, "_update_download_status", update_status),
+        patch.object(download_tasks, "_create_download_history", create_history),
+        patch.object(download_tasks, "_trigger_webhooks", trigger_webhooks),
+        patch.object(download_tasks, "redis_progress_service", redis_progress_service),
+    ):
+        result = await download_tasks._download_video_task(
+            download_id="download-123",
+            url="https://example.test/watch",
+        )
+
+    assert result == {
+        "success": False,
+        "download_id": "download-123",
+        "error": "Failed to extract video information",
+    }
+    yt_service.download_video.assert_not_awaited()
+
+    failed_call = update_status.await_args_list[-1]
+    assert failed_call.args == ("download-123", "failed")
+    assert failed_call.kwargs["error_message"] == "Failed to extract video information"
+
+    create_history.assert_awaited_once()
+    assert create_history.await_args.kwargs["status"] == "failed"
+    assert (
+        create_history.await_args.kwargs["error_message"]
+        == "Failed to extract video information"
+    )
+    assert trigger_webhooks.await_args_list[-1] == call(
+        "download_failed",
+        "download-123",
+        {
+            "url": "https://example.test/watch",
+            "error": "Failed to extract video information",
+        },
+    )
+    redis_progress_service.delete_progress.assert_awaited_once_with("download-123")
+    redis_progress_service.revoke_user_sse_tokens.assert_awaited_once_with(
+        user_id="*", scope_prefix="download:download-123"
+    )
+
+
+@pytest.mark.asyncio
+async def test_download_video_task_missing_file_marks_failed(tmp_path):
+    yt_service = AsyncMock()
+    yt_service.extract_info.return_value = {"title": "Missing File"}
+    yt_service.download_video.return_value = str(tmp_path / "missing-file.mp4")
+
+    update_status = AsyncMock()
+    create_history = AsyncMock()
+    trigger_webhooks = AsyncMock()
+    redis_progress_service = AsyncMock()
+
+    with (
+        patch.object(download_tasks, "yt_service", yt_service),
+        patch.object(download_tasks, "_update_download_status", update_status),
+        patch.object(download_tasks, "_create_download_history", create_history),
+        patch.object(download_tasks, "_trigger_webhooks", trigger_webhooks),
+        patch.object(download_tasks, "redis_progress_service", redis_progress_service),
+    ):
+        result = await download_tasks._download_video_task(
+            download_id="download-123",
+            url="https://example.test/watch",
+            output_path=str(tmp_path),
+        )
+
+    assert result == {
+        "success": False,
+        "download_id": "download-123",
+        "error": "Download completed but file not found",
+    }
+    failed_call = update_status.await_args_list[-1]
+    assert failed_call.args == ("download-123", "failed")
+    assert (
+        failed_call.kwargs["error_message"] == "Download completed but file not found"
+    )
+    assert create_history.await_args.kwargs["status"] == "failed"
+    assert (
+        create_history.await_args.kwargs["error_message"]
+        == "Download completed but file not found"
+    )
+    assert trigger_webhooks.await_args_list[-1] == call(
+        "download_failed",
+        "download-123",
+        {
+            "url": "https://example.test/watch",
+            "error": "Download completed but file not found",
+        },
+    )
+    redis_progress_service.delete_progress.assert_awaited_once_with("download-123")
+
+
+@pytest.mark.asyncio
+async def test_download_progress_hook_normalizes_progress_and_keeps_metadata(tmp_path):
+    download_file = tmp_path / "Progress_Video.mp4"
+    scheduled_coroutines = []
+    yt_service = AsyncMock()
+    yt_service.extract_info.return_value = {
+        "title": "Progress Video",
+        "thumbnail": "https://example.test/thumb.jpg",
+        "extractor": "ExampleSite",
+        "description": "Progress example",
+        "duration": 99,
+    }
+
+    async def fake_download_video(
+        url, output_path, format_spec, progress_callback=None, **kwargs
+    ):
+        assert progress_callback is not None
+        progress_callback(
+            {
+                "status": "downloading",
+                "downloaded_bytes": 500,
+                "total_bytes": 100,
+                "speed": 12,
+                "eta": 3,
+            }
+        )
+        progress_callback(
+            {
+                "status": "downloading",
+                "downloaded_bytes": 50,
+                "total_bytes": 100,
+                "speed": 8.5,
+                "eta": 2.5,
+            }
+        )
+        download_file.write_bytes(b"video")
+        return str(download_file)
+
+    def fake_run_coroutine_threadsafe(coro, loop):
+        scheduled_coroutines.append(coro)
+        coro.close()
+        return Mock()
+
+    yt_service.download_video.side_effect = fake_download_video
+
+    update_status = AsyncMock()
+    create_history = AsyncMock()
+    trigger_webhooks = AsyncMock()
+    redis_progress_service = Mock()
+    redis_progress_service.publish_stats_update = AsyncMock()
+    redis_progress_service.delete_progress = AsyncMock()
+    redis_progress_service.revoke_user_sse_tokens = AsyncMock(return_value=0)
+
+    with (
+        patch.object(download_tasks, "yt_service", yt_service),
+        patch.object(download_tasks, "_update_download_status", update_status),
+        patch.object(download_tasks, "_create_download_history", create_history),
+        patch.object(download_tasks, "_trigger_webhooks", trigger_webhooks),
+        patch.object(download_tasks, "redis_progress_service", redis_progress_service),
+        patch.object(
+            asyncio,
+            "run_coroutine_threadsafe",
+            side_effect=fake_run_coroutine_threadsafe,
+        ),
+        patch.object(download_tasks.time, "time", side_effect=[10.0, 12.5]),
+    ):
+        result = await download_tasks._download_video_task(
+            download_id="download-123",
+            url="https://example.test/watch",
+            output_path=str(tmp_path),
+        )
+
+    assert result["success"] is True
+    assert len(scheduled_coroutines) == 4
+
+    first_progress = redis_progress_service.set_progress_sync.call_args_list[0].args[1]
+    assert first_progress["message"] == "Downloading: 5.0%"
+    assert first_progress["progress"] == {
+        "percentage": 5.0,
+        "status": "downloading",
+        "downloaded_bytes": 500,
+        "total_bytes": 100,
+        "speed": 12.0,
+        "eta": 3.0,
+    }
+    assert first_progress["result"] == {
+        "url": "https://example.test/watch",
+        "title": "Progress Video",
+        "thumbnail_url": "https://example.test/thumb.jpg",
+        "extractor": "ExampleSite",
+        "description": "Progress example",
+        "duration": 99,
+    }
+
+    second_progress = redis_progress_service.set_progress_sync.call_args_list[1].args[1]
+    assert second_progress["message"] == "Downloading: 50.0%"
+    assert second_progress["progress"]["percentage"] == 50.0
+    assert second_progress["progress"]["speed"] == 8.5
+    assert second_progress["progress"]["eta"] == 2.5
+
+
+@pytest.mark.asyncio
+async def test_batch_download_task_aggregates_results_and_triggers_webhooks():
+    download_task = AsyncMock(
+        side_effect=[
+            {"success": True, "download_id": "download-1", "file_size": 100},
+            {"success": False, "download_id": "download-2", "error": "failed"},
+        ]
+    )
+    trigger_webhooks = AsyncMock()
+
+    with (
+        patch.object(download_tasks, "_download_video_task", download_task),
+        patch.object(download_tasks, "_trigger_webhooks", trigger_webhooks),
+    ):
+        result = await download_tasks._batch_download_task(
+            download_ids=["download-1", "download-2"],
+            urls=["https://example.test/one", "https://example.test/two"],
+            format_spec="best",
+            output_directory="/downloads/batch",
+            write_thumbnail=True,
+        )
+
+    assert result == {
+        "batch_id": "batch_2_urls",
+        "total_downloads": 2,
+        "successful_downloads": 1,
+        "results": [
+            {"success": True, "download_id": "download-1", "file_size": 100},
+            {"success": False, "download_id": "download-2", "error": "failed"},
+        ],
+    }
+    assert download_task.await_args_list == [
+        call(
+            download_id="download-1",
+            url="https://example.test/one",
+            format_spec="best",
+            output_path="/downloads/batch",
+            write_thumbnail=True,
+        ),
+        call(
+            download_id="download-2",
+            url="https://example.test/two",
+            format_spec="best",
+            output_path="/downloads/batch",
+            write_thumbnail=True,
+        ),
+    ]
+    assert trigger_webhooks.await_args_list == [
+        call(
+            "batch_download_started",
+            "batch_2_urls",
+            {
+                "urls": ["https://example.test/one", "https://example.test/two"],
+                "total_videos": 2,
+            },
+        ),
+        call(
+            "batch_download_completed",
+            "batch_2_urls",
+            {
+                "total_videos": 2,
+                "successful_downloads": 1,
+                "failed_downloads": 1,
+                "results": [
+                    {"success": True, "download_id": "download-1", "file_size": 100},
+                    {"success": False, "download_id": "download-2", "error": "failed"},
+                ],
+            },
+        ),
+    ]

--- a/packages/hermes-api/tests/test_tasks/test_download_tasks.py
+++ b/packages/hermes-api/tests/test_tasks/test_download_tasks.py
@@ -63,6 +63,26 @@ async def test_publish_sse_progress_shapes_download_status_payload():
 
 
 @pytest.mark.asyncio
+async def test_publish_sse_progress_keeps_zero_percent_message():
+    mock_progress_service = AsyncMock()
+
+    with patch.object(download_tasks, "redis_progress_service", mock_progress_service):
+        await download_tasks._publish_sse_progress(
+            download_id="download-123",
+            status="downloading",
+            progress=0.0,
+            downloaded_bytes=0,
+            total_bytes=1000,
+        )
+
+    progress_data = mock_progress_service.publish_download_progress.await_args.kwargs[
+        "progress_data"
+    ]
+    assert progress_data["message"] == "Downloading: 0.0%"
+    assert progress_data["progress"]["percentage"] == 0.0
+
+
+@pytest.mark.asyncio
 async def test_update_download_status_publishes_cached_db_progress_for_active_status(
     db_session,
 ):

--- a/packages/hermes-api/tests/test_utils.py
+++ b/packages/hermes-api/tests/test_utils.py
@@ -1,0 +1,80 @@
+"""Tests for shared utility helpers."""
+
+from app.utils.download_progress import (
+    build_download_progress_payload,
+    progress_fields_from_payload,
+)
+
+
+def test_build_download_progress_payload_uses_nested_progress_shape():
+    payload = build_download_progress_payload(
+        status="downloading",
+        message="Downloading: 25.0%",
+        progress=25.0,
+        downloaded_bytes=250,
+        total_bytes=1000,
+        download_speed=42.0,
+        eta=12.0,
+        result={"title": "Video"},
+        include_progress=True,
+    )
+
+    assert payload == {
+        "status": "downloading",
+        "message": "Downloading: 25.0%",
+        "progress": {
+            "percentage": 25.0,
+            "status": "downloading",
+            "downloaded_bytes": 250,
+            "total_bytes": 1000,
+            "speed": 42.0,
+            "eta": 12.0,
+        },
+        "result": {"title": "Video"},
+    }
+
+
+def test_progress_fields_from_payload_accepts_nested_task_payload():
+    fields = progress_fields_from_payload(
+        {
+            "status": "downloading",
+            "progress": {
+                "percentage": 66.0,
+                "status": "downloading",
+                "downloaded_bytes": 660,
+                "total_bytes": 1000,
+                "speed": 100.0,
+                "eta": 4.0,
+            },
+        },
+        fallback_status="processing",
+    )
+
+    assert fields == {
+        "percentage": 66.0,
+        "status": "downloading",
+        "downloaded_bytes": 660,
+        "total_bytes": 1000,
+        "speed": 100.0,
+        "eta": 4.0,
+    }
+
+
+def test_progress_fields_from_payload_accepts_legacy_flat_payload():
+    fields = progress_fields_from_payload(
+        {
+            "percentage": 12.0,
+            "downloaded_bytes": 120,
+            "total_bytes": 1000,
+        },
+        fallback_status="downloading",
+    )
+
+    assert fields == {
+        "percentage": 12.0,
+        "status": "downloading",
+        "downloaded_bytes": 120,
+        "total_bytes": 1000,
+        "speed": None,
+        "eta": None,
+    }

--- a/packages/hermes-app/src/components/download/VideoPreview.tsx
+++ b/packages/hermes-app/src/components/download/VideoPreview.tsx
@@ -30,6 +30,7 @@ import { toast } from 'sonner'
 import { cn, formatDate } from '@/lib/utils'
 import { useQueryClient } from '@tanstack/react-query'
 import { taskTracker } from '@/lib/taskTracking'
+import { invalidateQueueQueries } from '@/lib/queryClient'
 
 interface VideoPreviewProps {
   info: VideoInfo
@@ -187,9 +188,7 @@ export function VideoPreview({ info, onDownload, isDownloading }: VideoPreviewPr
           `in ${successfulBatches} batch${successfulBatches !== 1 ? 'es' : ''}`
         )
         
-        // Invalidate queries to refresh UI (same as single download behavior)
-        queryClient.invalidateQueries({ queryKey: ['queueStats'] })
-        queryClient.invalidateQueries({ queryKey: ['recentDownloadsQueue'] })
+        invalidateQueueQueries(queryClient)
       } else {
         toast.error('Failed to queue any batches. Please check the console for details.')
       }

--- a/packages/hermes-app/src/components/queue/QueueCard.tsx
+++ b/packages/hermes-app/src/components/queue/QueueCard.tsx
@@ -20,6 +20,7 @@ import { ConfirmationDialog } from '@/components/ui/confirmation-dialog'
 import { Blur } from '@/components/animate-ui/primitives/effects/blur'
 import { useState } from 'react'
 import type { DownloadStatus, DownloadResult } from '@/types'
+import { invalidateQueueQueries } from '@/lib/queryClient'
 
 // Type guard to check if result is a proper DownloadResult
 const isDownloadResult = (result: unknown): result is DownloadResult => {
@@ -53,16 +54,7 @@ export function QueueCard({ download, isSelectable = false, isSelected = false, 
         if (data.deletedFiles > 0) {
           toast.success(`File deleted! Freed ${(data.totalFreedSpace / 1024 / 1024).toFixed(2)} MB`)
         }
-        // Invalidate all queue-related queries to ensure UI updates
-        // Invalidate queue queries with different filter combinations
-        queryClient.invalidateQueries({ queryKey: ['queue'], exact: false })
-        queryClient.invalidateQueries({ queryKey: ['queue', 'active'], exact: false })
-        queryClient.invalidateQueries({ queryKey: ['queue', 'history'], exact: false })
-        queryClient.invalidateQueries({ queryKey: ['queue', 'all'], exact: false })
-        queryClient.invalidateQueries({ queryKey: ['queueStats'], exact: false })
-        queryClient.invalidateQueries({ queryKey: ['recentDownloadsQueue'], exact: false })
-        // Also invalidate files list to keep it in sync
-        queryClient.invalidateQueries({ queryKey: ['files'], exact: false })
+        invalidateQueueQueries(queryClient, { includeFiles: true })
       }, 600) // Match animation duration
     },
     onError: (error) => {

--- a/packages/hermes-app/src/components/queue/QueueList.tsx
+++ b/packages/hermes-app/src/components/queue/QueueList.tsx
@@ -1,5 +1,3 @@
-import { useQuery } from '@tanstack/react-query'
-import { apiClient } from '@/services/api/client'
 import { useQueueUpdatesSSE } from '@/hooks/useQueueUpdatesSSE'
 import { QueueCard } from './QueueCard'
 import { QueueSkeleton } from './QueueSkeleton'
@@ -10,6 +8,7 @@ import { FileVideo, Clock, CheckCircle } from 'lucide-react'
 import { useMemo } from 'react'
 import { useFilteredDownloads } from '@/hooks/useFilters'
 import type { components } from '@/types/api.generated'
+import { useQueueData } from '@/hooks/useQueueData'
 
 type DownloadStatus = components["schemas"]["DownloadStatus"]
 
@@ -45,17 +44,9 @@ export function QueueList({
   const { isConnected, isReconnecting, reconnectAttempts } = useQueueUpdatesSSE();
 
   // Initial data load
-  const { data: queueData, isLoading, error, refetch } = useQuery({
-    queryKey: ['queue', statusFilter, viewMode],
-    queryFn: () => {
-      const status = viewMode === 'active'
-        ? (statusFilter === 'all' ? undefined : statusFilter)
-        : viewMode === 'history'
-        ? 'completed'
-        : undefined;
-      return apiClient.getDownloadQueue(status, 20, 0);
-    },
-    staleTime: Infinity, // Data stays fresh via SSE invalidation
+  const { data: queueData, isLoading, error, refetch } = useQueueData({
+    statusFilter,
+    viewMode,
   })
 
   // Use the useFilteredDownloads hook for filtering and sorting
@@ -200,4 +191,3 @@ export function QueueList({
     </div>
   )
 }
-

--- a/packages/hermes-app/src/components/queue/QueueTabContent.tsx
+++ b/packages/hermes-app/src/components/queue/QueueTabContent.tsx
@@ -2,10 +2,9 @@ import { Card, CardContent } from '@/components/ui/card'
 import { QueueList } from './QueueList'
 import { QueueStats } from './QueueStats'
 import { BulkOperations } from './BulkOperations'
-import { useQuery } from '@tanstack/react-query'
-import { apiClient } from '@/services/api/client'
-import type { components } from '@/types/api.generated'
 import { useBulkOperations } from '@/hooks/useBulkOperations'
+import { useQueueData } from '@/hooks/useQueueData'
+import { toBulkOperationItems } from '@/lib/queueData'
 
 import type { FilterState } from '@/hooks/useFilters'
 
@@ -33,18 +32,11 @@ export function QueueTabContent({
 
   // Get current queue data for bulk operations
   // Uses same query key as QueueList so SSE invalidation updates both
-  const { data: queueData } = useQuery({
-    queryKey: ['queue', statusFilter, viewMode],
-    queryFn: () => {
-      const status = viewMode === 'active'
-        ? (statusFilter === 'all' ? undefined : statusFilter)
-        : viewMode === 'history'
-        ? 'completed'
-        : undefined;
-      return apiClient.getDownloadQueue(status, 20, 0);
-    },
-    staleTime: Infinity, // Data stays fresh via SSE invalidation
+  const { data: queueData } = useQueueData({
+    statusFilter,
+    viewMode,
   })
+  const bulkItems = toBulkOperationItems(queueData?.items)
 
   return (
     <div className="space-y-4">
@@ -54,41 +46,13 @@ export function QueueTabContent({
       <BulkOperations
         selectedCount={bulkOperations.selectedCount}
         totalCount={queueData?.items?.length || 0}
-        selectedItems={bulkOperations.getSelectedItems(
-          queueData?.items?.map((item: components["schemas"]["DownloadStatus"]) => ({
-            id: item.downloadId,
-            title: String(item.result?.title || item.downloadId),
-            filePath: item.currentFilename || undefined,
-            status: item.status
-          })) || []
-        )}
+        selectedItems={bulkOperations.getSelectedItems(bulkItems)}
         onSelectAll={() => {
-          if (queueData?.items) {
-            bulkOperations.selectAll(queueData.items.map((item: components["schemas"]["DownloadStatus"]) => ({
-              id: item.downloadId,
-              title: String(item.result?.title || item.downloadId),
-              filePath: item.currentFilename || undefined,
-              status: item.status
-            })))
-          }
+          bulkOperations.selectAll(bulkItems)
         }}
         onDeselectAll={bulkOperations.deselectAll}
-        onBulkDelete={() => bulkOperations.bulkDelete(
-          queueData?.items?.map((item: components["schemas"]["DownloadStatus"]) => ({
-            id: item.downloadId,
-            title: String(item.result?.title || item.downloadId),
-            filePath: item.currentFilename || undefined,
-            status: item.status
-          })) || []
-        )}
-        onBulkCancel={() => bulkOperations.bulkCancel(
-          queueData?.items?.map((item: components["schemas"]["DownloadStatus"]) => ({
-            id: item.downloadId,
-            title: String(item.result?.title || item.downloadId),
-            filePath: item.currentFilename || undefined,
-            status: item.status
-          })) || []
-        )}
+        onBulkDelete={() => bulkOperations.bulkDelete(bulkItems)}
+        onBulkCancel={() => bulkOperations.bulkCancel(bulkItems)}
         isProcessing={bulkOperations.isProcessing}
       />
 
@@ -103,14 +67,7 @@ export function QueueTabContent({
             isSelectable={true}
             selectedItems={bulkOperations.selectedItems}
             onToggleSelect={bulkOperations.toggleItem}
-            onSelectAll={(items) => bulkOperations.selectAll(
-              items.map(item => ({
-                id: item.downloadId,
-                title: String(item.result?.title || item.downloadId),
-                filePath: item.currentFilename || undefined,
-                status: item.status
-              }))
-            )}
+            onSelectAll={(items) => bulkOperations.selectAll(toBulkOperationItems(items))}
             onDeselectAll={bulkOperations.deselectAll}
           />
         </CardContent>

--- a/packages/hermes-app/src/hooks/__tests__/useBulkOperations.test.tsx
+++ b/packages/hermes-app/src/hooks/__tests__/useBulkOperations.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * Tests for useBulkOperations hook.
+ *
+ * The API client and delete mutation are mocked so these tests cover the hook's
+ * selection, filtering, cleanup, and error-handling logic.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { apiClient } from '@/services/api/client'
+import { toast } from 'sonner'
+import { useBulkOperations } from '../useBulkOperations'
+import { useDeleteFiles } from '../useDownloadActions'
+
+vi.mock('../useDownloadActions', () => ({
+  useDeleteFiles: vi.fn(),
+}))
+
+vi.mock('@/services/api/client', () => ({
+  apiClient: {
+    cancelDownload: vi.fn(),
+  },
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+const mutateAsync = vi.fn()
+const mockUseDeleteFiles = vi.mocked(useDeleteFiles)
+const mockCancelDownload = vi.mocked(apiClient.cancelDownload)
+const mockToast = vi.mocked(toast)
+
+type BulkItem = Parameters<
+  ReturnType<typeof useBulkOperations>['bulkDelete']
+>[0][number]
+
+function renderBulkOperations(options?: Parameters<typeof useBulkOperations>[0]) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+
+  return {
+    ...renderHook(() => useBulkOperations(options), { wrapper }),
+    invalidateQueries,
+  }
+}
+
+describe('useBulkOperations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseDeleteFiles.mockReturnValue(
+      { mutateAsync } as unknown as ReturnType<typeof useDeleteFiles>
+    )
+    mutateAsync.mockResolvedValue({
+      deletedFiles: 1,
+      failedDeletions: [],
+      totalFreedSpace: 1024,
+    })
+    mockCancelDownload.mockResolvedValue({
+      downloadId: 'download-1',
+      cancelled: true,
+      message: 'Cancelled',
+    })
+  })
+
+  it('rejects bulk delete when nothing is selected', async () => {
+    const { result } = renderBulkOperations()
+
+    await act(async () => {
+      await result.current.bulkDelete([])
+    })
+
+    expect(mockToast.error).toHaveBeenCalledWith('No items selected')
+    expect(mutateAsync).not.toHaveBeenCalled()
+    expect(result.current.isProcessing).toBe(false)
+  })
+
+  it('rejects bulk delete when selected items have no file paths', async () => {
+    const items: BulkItem[] = [
+      { id: 'download-1', title: 'No file yet', status: 'completed' },
+    ]
+    const { result } = renderBulkOperations()
+
+    act(() => {
+      result.current.selectItem('download-1')
+    })
+    await act(async () => {
+      await result.current.bulkDelete(items)
+    })
+
+    expect(mockToast.error).toHaveBeenCalledWith(
+      'No downloadable files found in selection'
+    )
+    expect(mutateAsync).not.toHaveBeenCalled()
+    expect(result.current.selectedCount).toBe(1)
+  })
+
+  it('deletes only selected files with paths and clears selection on success', async () => {
+    const onSuccess = vi.fn()
+    const items: BulkItem[] = [
+      {
+        id: 'download-1',
+        title: 'Selected with file',
+        filePath: '/downloads/one.mp4',
+        status: 'completed',
+      },
+      {
+        id: 'download-2',
+        title: 'Selected without file',
+        status: 'completed',
+      },
+      {
+        id: 'download-3',
+        title: 'Unselected with file',
+        filePath: '/downloads/three.mp4',
+        status: 'completed',
+      },
+    ]
+    const { result } = renderBulkOperations({ onSuccess })
+
+    act(() => {
+      result.current.selectItem('download-1')
+      result.current.selectItem('download-2')
+    })
+    await act(async () => {
+      await result.current.bulkDelete(items)
+    })
+
+    expect(mutateAsync).toHaveBeenCalledWith(['/downloads/one.mp4'])
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+    expect(result.current.selectedCount).toBe(0)
+    expect(result.current.isProcessing).toBe(false)
+  })
+
+  it('cancels only selected queued, downloading, or processing items', async () => {
+    const onSuccess = vi.fn()
+    const items: BulkItem[] = [
+      { id: 'queued', title: 'Queued', status: 'queued' },
+      { id: 'downloading', title: 'Downloading', status: 'downloading' },
+      { id: 'processing', title: 'Processing', status: 'processing' },
+      { id: 'completed', title: 'Completed', status: 'completed' },
+      { id: 'unselected', title: 'Unselected', status: 'queued' },
+    ]
+    const { result, invalidateQueries } = renderBulkOperations({ onSuccess })
+
+    act(() => {
+      result.current.selectItem('queued')
+      result.current.selectItem('downloading')
+      result.current.selectItem('processing')
+      result.current.selectItem('completed')
+    })
+    await act(async () => {
+      await result.current.bulkCancel(items)
+    })
+
+    expect(mockCancelDownload).toHaveBeenCalledTimes(3)
+    expect(mockCancelDownload).toHaveBeenCalledWith('queued')
+    expect(mockCancelDownload).toHaveBeenCalledWith('downloading')
+    expect(mockCancelDownload).toHaveBeenCalledWith('processing')
+    expect(mockCancelDownload).not.toHaveBeenCalledWith('completed')
+    expect(mockCancelDownload).not.toHaveBeenCalledWith('unselected')
+    expect(mockToast.success).toHaveBeenCalledWith('Cancelled 3 downloads')
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['queue'],
+      exact: false,
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['queueStats'],
+      exact: false,
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['recentDownloadsQueue'],
+      exact: false,
+    })
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+    expect(result.current.selectedCount).toBe(0)
+  })
+
+  it('reports bulk cancel failures and preserves the selection', async () => {
+    const onError = vi.fn()
+    const items: BulkItem[] = [
+      { id: 'queued', title: 'Queued', status: 'queued' },
+    ]
+    mockCancelDownload.mockRejectedValueOnce(new Error('Network failed'))
+    const { result } = renderBulkOperations({ onError })
+
+    act(() => {
+      result.current.selectItem('queued')
+    })
+    await act(async () => {
+      await result.current.bulkCancel(items)
+    })
+
+    expect(mockToast.error).toHaveBeenCalledWith(
+      'Failed to cancel downloads: Network failed'
+    )
+    expect(onError).toHaveBeenCalledWith(expect.any(Error))
+    expect(result.current.selectedCount).toBe(1)
+    expect(result.current.isProcessing).toBe(false)
+  })
+})

--- a/packages/hermes-app/src/hooks/__tests__/useBulkOperations.test.tsx
+++ b/packages/hermes-app/src/hooks/__tests__/useBulkOperations.test.tsx
@@ -179,14 +179,7 @@ describe('useBulkOperations', () => {
       queryKey: ['queue'],
       exact: false,
     })
-    expect(invalidateQueries).toHaveBeenCalledWith({
-      queryKey: ['queueStats'],
-      exact: false,
-    })
-    expect(invalidateQueries).toHaveBeenCalledWith({
-      queryKey: ['recentDownloadsQueue'],
-      exact: false,
-    })
+    expect(invalidateQueries).toHaveBeenCalledTimes(1)
     expect(onSuccess).toHaveBeenCalledTimes(1)
     expect(result.current.selectedCount).toBe(0)
   })

--- a/packages/hermes-app/src/hooks/__tests__/useDownloadActions.test.tsx
+++ b/packages/hermes-app/src/hooks/__tests__/useDownloadActions.test.tsx
@@ -1,0 +1,135 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+import { apiClient } from '@/services/api/client'
+import {
+  useCancelDownload,
+  useDeleteFiles,
+  useStartDownload,
+} from '../useDownloadActions'
+
+vi.mock('@/services/api/client', () => ({
+  apiClient: {
+    startDownload: vi.fn(),
+    deleteFiles: vi.fn(),
+    cancelDownload: vi.fn(),
+  },
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}))
+
+const mockStartDownload = vi.mocked(apiClient.startDownload)
+const mockDeleteFiles = vi.mocked(apiClient.deleteFiles)
+const mockCancelDownload = vi.mocked(apiClient.cancelDownload)
+const mockToast = vi.mocked(toast)
+
+function renderWithQueryClient<T>(hook: () => T) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+
+  return {
+    ...renderHook(hook, { wrapper }),
+    invalidateQueries,
+  }
+}
+
+describe('useDownloadActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockStartDownload.mockResolvedValue({
+      downloadId: 'download-1',
+      status: 'pending',
+      message: 'Queued',
+    })
+    mockDeleteFiles.mockResolvedValue({
+      deletedFiles: 1,
+      failedDeletions: [],
+      totalFreedSpace: 1024 * 1024,
+    })
+    mockCancelDownload.mockResolvedValue({
+      downloadId: 'download-1',
+      cancelled: true,
+      message: 'Cancelled',
+    })
+  })
+
+  it('invalidates queue data after starting a download', async () => {
+    const { result, invalidateQueries } = renderWithQueryClient(useStartDownload)
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        url: 'https://example.test/watch',
+        format: 'best',
+        downloadSubtitles: false,
+        downloadThumbnail: false,
+      })
+    })
+
+    expect(mockStartDownload).toHaveBeenCalledWith({
+      url: 'https://example.test/watch',
+      format: 'best',
+      downloadSubtitles: false,
+      downloadThumbnail: false,
+    })
+    expect(mockToast.success).toHaveBeenCalledWith(
+      'Download started successfully!'
+    )
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['queue'],
+      exact: false,
+    })
+    expect(invalidateQueries).toHaveBeenCalledTimes(1)
+  })
+
+  it('invalidates queue and files data after deleting files', async () => {
+    const { result, invalidateQueries } = renderWithQueryClient(useDeleteFiles)
+
+    await act(async () => {
+      await result.current.mutateAsync(['/downloads/video.mp4'])
+    })
+
+    expect(mockDeleteFiles).toHaveBeenCalledWith(['/downloads/video.mp4'])
+    expect(mockToast.success).toHaveBeenCalledWith('Files deleted! Freed 1.00 MB')
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['queue'],
+      exact: false,
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['files'],
+      exact: false,
+    })
+    expect(invalidateQueries).toHaveBeenCalledTimes(2)
+  })
+
+  it('invalidates queue data after cancelling a download', async () => {
+    const { result, invalidateQueries } = renderWithQueryClient(useCancelDownload)
+
+    await act(async () => {
+      await result.current.mutateAsync('download-1')
+    })
+
+    expect(mockCancelDownload).toHaveBeenCalledWith('download-1')
+    expect(mockToast.success).toHaveBeenCalledWith('Download cancelled')
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['queue'],
+      exact: false,
+    })
+    expect(invalidateQueries).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/hermes-app/src/hooks/__tests__/useQueueData.test.ts
+++ b/packages/hermes-app/src/hooks/__tests__/useQueueData.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { getQueueQueryKey } from '../useQueueData'
+
+describe('useQueueData helpers', () => {
+  it('keys queue data by filter, view, and pagination', () => {
+    expect(getQueueQueryKey('downloading', 'active', 50, 20)).toEqual([
+      'queue',
+      'downloading',
+      'active',
+      50,
+      20,
+    ])
+  })
+})

--- a/packages/hermes-app/src/hooks/__tests__/useQueueData.test.ts
+++ b/packages/hermes-app/src/hooks/__tests__/useQueueData.test.ts
@@ -1,14 +1,86 @@
-import { describe, expect, it } from 'vitest'
-import { getQueueQueryKey } from '../useQueueData'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createElement, type ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { apiClient } from '@/services/api/client'
+import { getQueueQueryKey, useQueueData } from '../useQueueData'
+
+vi.mock('@/services/api/client', () => ({
+  apiClient: {
+    getDownloadQueue: vi.fn(),
+  },
+}))
+
+const mockGetDownloadQueue = vi.mocked(apiClient.getDownloadQueue)
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient, children })
+}
 
 describe('useQueueData helpers', () => {
-  it('keys queue data by filter, view, and pagination', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetDownloadQueue.mockResolvedValue({
+      totalItems: 0,
+      pending: 0,
+      active: 0,
+      completed: 0,
+      failed: 0,
+      items: [],
+    })
+  })
+
+  it('keys queue data by effective request filter and pagination', () => {
     expect(getQueueQueryKey('downloading', 'active', 50, 20)).toEqual([
       'queue',
       'downloading',
-      'active',
       50,
       20,
     ])
+  })
+
+  it('normalizes ignored filters to avoid duplicate cache entries', () => {
+    expect(getQueueQueryKey('all', 'history')).toEqual([
+      'queue',
+      'completed',
+      20,
+      0,
+    ])
+    expect(getQueueQueryKey('failed', 'history')).toEqual(
+      getQueueQueryKey('all', 'history')
+    )
+    expect(getQueueQueryKey('downloading', 'all')).toEqual([
+      'queue',
+      'all',
+      20,
+      0,
+    ])
+  })
+
+  it('loads queue data with the effective status filter', async () => {
+    const wrapper = createWrapper()
+
+    const { result } = renderHook(
+      () =>
+        useQueueData({
+          statusFilter: 'failed',
+          viewMode: 'history',
+          limit: 10,
+          offset: 5,
+        }),
+      { wrapper }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockGetDownloadQueue).toHaveBeenCalledWith('completed', 10, 5)
+    expect(result.current.data?.items).toEqual([])
   })
 })

--- a/packages/hermes-app/src/hooks/useBulkOperations.ts
+++ b/packages/hermes-app/src/hooks/useBulkOperations.ts
@@ -3,6 +3,7 @@ import { useDeleteFiles } from './useDownloadActions'
 import { apiClient } from '@/services/api/client'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
+import { invalidateQueueQueries } from '@/lib/queryClient'
 
 interface BulkOperationItem {
   id: string
@@ -124,9 +125,7 @@ export function useBulkOperations(options: UseBulkOperationsOptions = {}) {
       await Promise.all(cancellableItems.map(item => apiClient.cancelDownload(item.id)))
       toast.success(`Cancelled ${cancellableItems.length} download${cancellableItems.length !== 1 ? 's' : ''}`)
       deselectAll()
-      queryClient.invalidateQueries({ queryKey: ['queue'], exact: false })
-      queryClient.invalidateQueries({ queryKey: ['queueStats'], exact: false })
-      queryClient.invalidateQueries({ queryKey: ['recentDownloadsQueue'], exact: false })
+      invalidateQueueQueries(queryClient)
       onSuccess?.()
     } catch (error) {
       toast.error(`Failed to cancel downloads: ${error instanceof Error ? error.message : 'Unknown error'}`)

--- a/packages/hermes-app/src/hooks/useBulkOperations.ts
+++ b/packages/hermes-app/src/hooks/useBulkOperations.ts
@@ -4,13 +4,7 @@ import { apiClient } from '@/services/api/client'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { invalidateQueueQueries } from '@/lib/queryClient'
-
-interface BulkOperationItem {
-  id: string
-  title: string
-  filePath?: string
-  status: string
-}
+import type { BulkOperationItem } from '@/lib/queueData'
 
 interface UseBulkOperationsOptions {
   onSuccess?: () => void

--- a/packages/hermes-app/src/hooks/useBulkOperations.ts
+++ b/packages/hermes-app/src/hooks/useBulkOperations.ts
@@ -85,17 +85,6 @@ export function useBulkOperations(options: UseBulkOperationsOptions = {}) {
     }
   }, [selectedItems, deleteMutation, deselectAll, onSuccess, onError])
 
-  const bulkRetry = useCallback(async () => {
-    const selectedItemIds = Array.from(selectedItems)
-    if (selectedItemIds.length === 0) {
-      toast.error('No items selected')
-      return
-    }
-
-    // TODO: Implement bulk retry functionality
-    toast.info('Bulk retry coming soon!')
-  }, [selectedItems])
-
   const bulkCancel = useCallback(async (items: BulkOperationItem[]) => {
     const selectedItemIds = Array.from(selectedItems)
     if (selectedItemIds.length === 0) {
@@ -149,7 +138,6 @@ export function useBulkOperations(options: UseBulkOperationsOptions = {}) {
     // Bulk operations
     bulkDelete,
     bulkCancel,
-    bulkRetry,
 
     // Utilities
     getSelectedItems,

--- a/packages/hermes-app/src/hooks/useDownloadActions.ts
+++ b/packages/hermes-app/src/hooks/useDownloadActions.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiClient } from '@/services/api/client'
 import { toast } from 'sonner'
 import type { components } from '@/types/api.generated'
+import { invalidateQueueQueries } from '@/lib/queryClient'
 
 type DownloadRequest = components["schemas"]["DownloadRequest"]
 import { TokenStorage } from '@/utils/tokenStorage'
@@ -13,13 +14,7 @@ export function useStartDownload() {
     mutationFn: (request: DownloadRequest) => apiClient.startDownload(request),
     onSuccess: () => {
       toast.success('Download started successfully!')
-      // Invalidate queue queries with different filter combinations
-      queryClient.invalidateQueries({ queryKey: ['queue'], exact: false })
-      queryClient.invalidateQueries({ queryKey: ['queue', 'active'], exact: false })
-      queryClient.invalidateQueries({ queryKey: ['queue', 'history'], exact: false })
-      queryClient.invalidateQueries({ queryKey: ['queue', 'all'], exact: false })
-      queryClient.invalidateQueries({ queryKey: ['queueStats'], exact: false })
-      queryClient.invalidateQueries({ queryKey: ['recentDownloadsQueue'], exact: false })
+      invalidateQueueQueries(queryClient)
     },
     onError: (error) => {
       toast.error(`Failed to start download: ${error.message}`)
@@ -40,14 +35,7 @@ export function useDeleteFiles() {
       } else {
         toast.warning('File was not found or already deleted')
       }
-      // Invalidate queue queries with different filter combinations
-      queryClient.invalidateQueries({ queryKey: ['queue'], exact: false })
-      queryClient.invalidateQueries({ queryKey: ['queue', 'active'], exact: false })
-      queryClient.invalidateQueries({ queryKey: ['queue', 'history'], exact: false })
-      queryClient.invalidateQueries({ queryKey: ['queue', 'all'], exact: false })
-      queryClient.invalidateQueries({ queryKey: ['queueStats'], exact: false })
-      // Also invalidate files list to keep it in sync
-      queryClient.invalidateQueries({ queryKey: ['files'], exact: false })
+      invalidateQueueQueries(queryClient, { includeFiles: true })
     },
     onError: (error) => {
       toast.error(`Failed to delete files: ${error.message}`)
@@ -117,12 +105,11 @@ export function useCancelDownload() {
     mutationFn: (downloadId: string) => apiClient.cancelDownload(downloadId),
     onSuccess: () => {
       toast.success('Download cancelled')
-      queryClient.invalidateQueries({ queryKey: ['queue'] })
+      invalidateQueueQueries(queryClient)
     },
     onError: (error) => {
       toast.error(`Failed to cancel download: ${error.message}`)
     },
   })
 }
-
 

--- a/packages/hermes-app/src/hooks/useQueueData.ts
+++ b/packages/hermes-app/src/hooks/useQueueData.ts
@@ -18,7 +18,12 @@ export function getQueueQueryKey(
   limit = 20,
   offset = 0
 ) {
-  return ['queue', statusFilter, viewMode, limit, offset] as const
+  return [
+    'queue',
+    getQueueStatusFilter(viewMode, statusFilter) ?? 'all',
+    limit,
+    offset,
+  ] as const
 }
 
 export function useQueueData({

--- a/packages/hermes-app/src/hooks/useQueueData.ts
+++ b/packages/hermes-app/src/hooks/useQueueData.ts
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query'
+import { apiClient } from '@/services/api/client'
+import {
+  getQueueStatusFilter,
+  type QueueViewMode,
+} from '@/lib/queueData'
+
+interface UseQueueDataOptions {
+  statusFilter: string
+  viewMode: QueueViewMode
+  limit?: number
+  offset?: number
+}
+
+export function getQueueQueryKey(
+  statusFilter: string,
+  viewMode: QueueViewMode
+) {
+  return ['queue', statusFilter, viewMode] as const
+}
+
+export function useQueueData({
+  statusFilter,
+  viewMode,
+  limit = 20,
+  offset = 0,
+}: UseQueueDataOptions) {
+  return useQuery({
+    queryKey: getQueueQueryKey(statusFilter, viewMode),
+    queryFn: () =>
+      apiClient.getDownloadQueue(
+        getQueueStatusFilter(viewMode, statusFilter),
+        limit,
+        offset
+      ),
+    staleTime: Infinity,
+  })
+}

--- a/packages/hermes-app/src/hooks/useQueueData.ts
+++ b/packages/hermes-app/src/hooks/useQueueData.ts
@@ -14,9 +14,11 @@ interface UseQueueDataOptions {
 
 export function getQueueQueryKey(
   statusFilter: string,
-  viewMode: QueueViewMode
+  viewMode: QueueViewMode,
+  limit = 20,
+  offset = 0
 ) {
-  return ['queue', statusFilter, viewMode] as const
+  return ['queue', statusFilter, viewMode, limit, offset] as const
 }
 
 export function useQueueData({
@@ -26,7 +28,7 @@ export function useQueueData({
   offset = 0,
 }: UseQueueDataOptions) {
   return useQuery({
-    queryKey: getQueueQueryKey(statusFilter, viewMode),
+    queryKey: getQueueQueryKey(statusFilter, viewMode, limit, offset),
     queryFn: () =>
       apiClient.getDownloadQueue(
         getQueueStatusFilter(viewMode, statusFilter),

--- a/packages/hermes-app/src/hooks/useQueueUpdatesSSE.test.tsx
+++ b/packages/hermes-app/src/hooks/useQueueUpdatesSSE.test.tsx
@@ -390,7 +390,7 @@ describe('useQueueUpdatesSSE', () => {
       })
     })
 
-    it('invalidates queueStats queries when updates arrive', async () => {
+    it('uses the queue prefix so stats queries refresh when updates arrive', async () => {
       const mockCreateSSEToken = vi.fn().mockResolvedValue({
         token: mockSSEToken,
         expires_at: '2025-12-31T23:59:59Z',
@@ -426,7 +426,7 @@ describe('useQueueUpdatesSSE', () => {
 
       await waitFor(() => {
         expect(invalidateQueriesSpy).toHaveBeenCalledWith({
-          queryKey: ['queueStats'],
+          queryKey: ['queue'],
           exact: false,
         })
       })

--- a/packages/hermes-app/src/hooks/useQueueUpdatesSSE.ts
+++ b/packages/hermes-app/src/hooks/useQueueUpdatesSSE.ts
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useSSE } from './useSSE';
 import { useSSEToken } from './useSSEToken';
 import { getApiBaseUrl } from '@/lib/config';
+import { invalidateQueueQueries } from '@/lib/queryClient';
 
 export interface QueueUpdate {
   action: 'added' | 'removed' | 'status_changed';
@@ -69,10 +70,7 @@ export function useQueueUpdatesSSE() {
   // Invalidate queue queries when updates arrive
   useEffect(() => {
     if (data) {
-      // Invalidate all queue-related queries
-      queryClient.invalidateQueries({ queryKey: ['queue'], exact: false });
-      queryClient.invalidateQueries({ queryKey: ['queueStats'], exact: false });
-      queryClient.invalidateQueries({ queryKey: ['recentDownloadsQueue'], exact: false });
+      invalidateQueueQueries(queryClient);
 
       // Optionally, update specific download in cache
       if (data.download_id) {

--- a/packages/hermes-app/src/lib/__tests__/queryClient.test.ts
+++ b/packages/hermes-app/src/lib/__tests__/queryClient.test.ts
@@ -156,7 +156,7 @@ describe('queryClient', () => {
   })
 
   describe('invalidateQueueQueries', () => {
-    it('invalidates every queue view that displays download state', () => {
+    it('invalidates the queue prefix that owns list and stats data', () => {
       const client = new QueryClient()
       const invalidateQueries = vi.spyOn(client, 'invalidateQueries')
 
@@ -166,30 +166,11 @@ describe('queryClient', () => {
         queryKey: ['queue'],
         exact: false,
       })
-      expect(invalidateQueries).toHaveBeenCalledWith({
-        queryKey: ['queue', 'active'],
-        exact: false,
-      })
-      expect(invalidateQueries).toHaveBeenCalledWith({
-        queryKey: ['queue', 'history'],
-        exact: false,
-      })
-      expect(invalidateQueries).toHaveBeenCalledWith({
-        queryKey: ['queue', 'all'],
-        exact: false,
-      })
-      expect(invalidateQueries).toHaveBeenCalledWith({
-        queryKey: ['queueStats'],
-        exact: false,
-      })
-      expect(invalidateQueries).toHaveBeenCalledWith({
-        queryKey: ['recentDownloadsQueue'],
-        exact: false,
-      })
       expect(invalidateQueries).not.toHaveBeenCalledWith({
         queryKey: ['files'],
         exact: false,
       })
+      expect(invalidateQueries).toHaveBeenCalledTimes(1)
     })
 
     it('can also invalidate downloaded file lists', () => {

--- a/packages/hermes-app/src/lib/__tests__/queryClient.test.ts
+++ b/packages/hermes-app/src/lib/__tests__/queryClient.test.ts
@@ -2,8 +2,9 @@
  * Tests for React Query client configuration
  */
 
-import { describe, it, expect } from 'vitest'
-import { queryClient } from '../queryClient'
+import { describe, it, expect, vi } from 'vitest'
+import { QueryClient } from '@tanstack/react-query'
+import { invalidateQueueQueries, queryClient } from '../queryClient'
 
 describe('queryClient', () => {
   describe('Configuration', () => {
@@ -151,6 +152,56 @@ describe('queryClient', () => {
     it('has retry set to 1', () => {
       const defaultOptions = queryClient.getDefaultOptions()
       expect(defaultOptions.mutations?.retry).toBe(1)
+    })
+  })
+
+  describe('invalidateQueueQueries', () => {
+    it('invalidates every queue view that displays download state', () => {
+      const client = new QueryClient()
+      const invalidateQueries = vi.spyOn(client, 'invalidateQueries')
+
+      invalidateQueueQueries(client)
+
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ['queue'],
+        exact: false,
+      })
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ['queue', 'active'],
+        exact: false,
+      })
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ['queue', 'history'],
+        exact: false,
+      })
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ['queue', 'all'],
+        exact: false,
+      })
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ['queueStats'],
+        exact: false,
+      })
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ['recentDownloadsQueue'],
+        exact: false,
+      })
+      expect(invalidateQueries).not.toHaveBeenCalledWith({
+        queryKey: ['files'],
+        exact: false,
+      })
+    })
+
+    it('can also invalidate downloaded file lists', () => {
+      const client = new QueryClient()
+      const invalidateQueries = vi.spyOn(client, 'invalidateQueries')
+
+      invalidateQueueQueries(client, { includeFiles: true })
+
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ['files'],
+        exact: false,
+      })
     })
   })
 })

--- a/packages/hermes-app/src/lib/__tests__/queueData.test.ts
+++ b/packages/hermes-app/src/lib/__tests__/queueData.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getQueueStatusFilter,
+  toBulkOperationItem,
+  toBulkOperationItems,
+  type DownloadStatus,
+} from '../queueData'
+
+describe('queueData helpers', () => {
+  it('resolves queue status filters from view state', () => {
+    expect(getQueueStatusFilter('active', 'all')).toBeUndefined()
+    expect(getQueueStatusFilter('active', 'downloading')).toBe('downloading')
+    expect(getQueueStatusFilter('history', 'failed')).toBe('completed')
+    expect(getQueueStatusFilter('all', 'failed')).toBeUndefined()
+  })
+
+  it('maps download status records into bulk operation items', () => {
+    const item = {
+      downloadId: 'download-123',
+      status: 'completed',
+      currentFilename: '/downloads/video.mp4',
+      result: {
+        title: 'Video title',
+      },
+      message: 'Download completed',
+      createdAt: '2026-01-01T00:00:00Z',
+    } as DownloadStatus
+
+    expect(toBulkOperationItem(item)).toEqual({
+      id: 'download-123',
+      title: 'Video title',
+      filePath: '/downloads/video.mp4',
+      status: 'completed',
+    })
+  })
+
+  it('falls back to download id and handles empty lists', () => {
+    const item = {
+      downloadId: 'download-123',
+      status: 'queued',
+      message: 'Queued',
+      createdAt: '2026-01-01T00:00:00Z',
+    } as DownloadStatus
+
+    expect(toBulkOperationItems([item])).toEqual([
+      {
+        id: 'download-123',
+        title: 'download-123',
+        filePath: undefined,
+        status: 'queued',
+      },
+    ])
+    expect(toBulkOperationItems(undefined)).toEqual([])
+  })
+})

--- a/packages/hermes-app/src/lib/queryClient.ts
+++ b/packages/hermes-app/src/lib/queryClient.ts
@@ -2,6 +2,10 @@
 
 import { QueryClient } from '@tanstack/react-query'
 
+interface InvalidateQueueOptions {
+  includeFiles?: boolean
+}
+
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -23,8 +27,18 @@ export const queryClient = new QueryClient({
   },
 })
 
+export function invalidateQueueQueries(
+  client: QueryClient,
+  options: InvalidateQueueOptions = {}
+) {
+  client.invalidateQueries({ queryKey: ['queue'], exact: false })
+  client.invalidateQueries({ queryKey: ['queue', 'active'], exact: false })
+  client.invalidateQueries({ queryKey: ['queue', 'history'], exact: false })
+  client.invalidateQueries({ queryKey: ['queue', 'all'], exact: false })
+  client.invalidateQueries({ queryKey: ['queueStats'], exact: false })
+  client.invalidateQueries({ queryKey: ['recentDownloadsQueue'], exact: false })
 
-
-
-
-
+  if (options.includeFiles) {
+    client.invalidateQueries({ queryKey: ['files'], exact: false })
+  }
+}

--- a/packages/hermes-app/src/lib/queryClient.ts
+++ b/packages/hermes-app/src/lib/queryClient.ts
@@ -32,11 +32,6 @@ export function invalidateQueueQueries(
   options: InvalidateQueueOptions = {}
 ) {
   client.invalidateQueries({ queryKey: ['queue'], exact: false })
-  client.invalidateQueries({ queryKey: ['queue', 'active'], exact: false })
-  client.invalidateQueries({ queryKey: ['queue', 'history'], exact: false })
-  client.invalidateQueries({ queryKey: ['queue', 'all'], exact: false })
-  client.invalidateQueries({ queryKey: ['queueStats'], exact: false })
-  client.invalidateQueries({ queryKey: ['recentDownloadsQueue'], exact: false })
 
   if (options.includeFiles) {
     client.invalidateQueries({ queryKey: ['files'], exact: false })

--- a/packages/hermes-app/src/lib/queueData.ts
+++ b/packages/hermes-app/src/lib/queueData.ts
@@ -1,0 +1,41 @@
+import type { components } from '@/types/api.generated'
+
+export type DownloadStatus = components["schemas"]["DownloadStatus"]
+export type QueueViewMode = 'active' | 'history' | 'all'
+
+export interface BulkOperationItem {
+  id: string
+  title: string
+  filePath?: string
+  status: string
+}
+
+export function getQueueStatusFilter(
+  viewMode: QueueViewMode,
+  statusFilter: string
+): string | undefined {
+  if (viewMode === 'active') {
+    return statusFilter === 'all' ? undefined : statusFilter
+  }
+
+  if (viewMode === 'history') {
+    return 'completed'
+  }
+
+  return undefined
+}
+
+export function toBulkOperationItem(item: DownloadStatus): BulkOperationItem {
+  return {
+    id: item.downloadId,
+    title: String(item.result?.title || item.downloadId),
+    filePath: item.currentFilename || undefined,
+    status: item.status,
+  }
+}
+
+export function toBulkOperationItems(
+  items: DownloadStatus[] | null | undefined
+): BulkOperationItem[] {
+  return items?.map(toBulkOperationItem) || []
+}

--- a/packages/hermes-app/src/services/__tests__/apiClient.test.ts
+++ b/packages/hermes-app/src/services/__tests__/apiClient.test.ts
@@ -225,4 +225,68 @@ describe('ApiClient - API Key Methods', () => {
       )
     })
   })
+
+  describe('query parameter methods', () => {
+    it('serializes defined file filters and skips undefined values', async () => {
+      const mockResponse = {
+        files: [],
+        totalCount: 0,
+        totalSize: 0,
+        directory: '/downloads',
+      }
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response)
+
+      const result = await apiClient.getDownloadedFiles({
+        extension: 'mp4',
+        limit: 25,
+        offset: 0,
+        max_size: undefined,
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/v1/files/?extension=mp4&limit=25&offset=0',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+          }),
+        })
+      )
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('combines timeline period with optional filters consistently', async () => {
+      const mockResponse = [
+        {
+          date: '2026-01-01',
+          downloads: 1,
+          successful: 1,
+          failed: 0,
+          totalSize: 1024,
+          avgDuration: 10,
+          successRate: 1,
+        },
+      ]
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response)
+
+      const result = await apiClient.getTimelineStats('month', {
+        extractor: 'youtube',
+        status: 'completed',
+        start_date: undefined,
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/v1/timeline/?period=month&extractor=youtube&status=completed',
+        expect.any(Object)
+      )
+      expect(result).toEqual(mockResponse)
+    })
+  })
 })

--- a/packages/hermes-app/src/services/api/client.ts
+++ b/packages/hermes-app/src/services/api/client.ts
@@ -49,6 +49,31 @@ interface ApiRequestInit extends RequestInit {
   skipAuth?: boolean
 }
 
+type SearchParamValue = string | number | boolean | null | undefined
+type SearchParams = Record<string, SearchParamValue>
+
+function buildSearchParams(
+  params?: SearchParams,
+  initialParams?: SearchParams
+): URLSearchParams {
+  const searchParams = new URLSearchParams()
+
+  const appendParams = (values?: SearchParams) => {
+    if (!values) return
+
+    Object.entries(values).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        searchParams.append(key, value.toString())
+      }
+    })
+  }
+
+  appendParams(initialParams)
+  appendParams(params)
+
+  return searchParams
+}
+
 class ApiClient {
   private baseURL: string
 
@@ -210,14 +235,7 @@ class ApiClient {
     limit?: number
     offset?: number
   }): Promise<FileList> {
-    const searchParams = new URLSearchParams()
-    if (params) {
-      Object.entries(params).forEach(([key, value]) => {
-        if (value !== undefined) {
-          searchParams.append(key, value.toString())
-        }
-      })
-    }
+    const searchParams = buildSearchParams(params)
     return this.request<FileList>(`/files/?${searchParams}`)
   }
 
@@ -230,14 +248,7 @@ class ApiClient {
     limit?: number
     offset?: number
   }): Promise<DownloadHistory> {
-    const searchParams = new URLSearchParams()
-    if (params) {
-      Object.entries(params).forEach(([key, value]) => {
-        if (value !== undefined) {
-          searchParams.append(key, value.toString())
-        }
-      })
-    }
+    const searchParams = buildSearchParams(params)
     return this.request<DownloadHistory>(`/history/?${searchParams}`)
   }
 
@@ -255,14 +266,7 @@ class ApiClient {
       status?: string
     }
   ): Promise<DailyStats[]> {
-    const searchParams = new URLSearchParams({ period })
-    if (params) {
-      Object.entries(params).forEach(([key, value]) => {
-        if (value !== undefined) {
-          searchParams.append(key, value.toString())
-        }
-      })
-    }
+    const searchParams = buildSearchParams(params, { period })
     return this.request<DailyStats[]>(`/timeline/?${searchParams}`)
   }
 
@@ -273,14 +277,7 @@ class ApiClient {
       end_date?: string
     }
   ): Promise<TimelineSummary> {
-    const searchParams = new URLSearchParams({ period })
-    if (params) {
-      Object.entries(params).forEach(([key, value]) => {
-        if (value !== undefined) {
-          searchParams.append(key, value.toString())
-        }
-      })
-    }
+    const searchParams = buildSearchParams(params, { period })
     return this.request<TimelineSummary>(`/timeline/summary?${searchParams}`)
   }
 

--- a/packages/hermes-app/tsconfig.test.json
+++ b/packages/hermes-app/tsconfig.test.json
@@ -4,6 +4,7 @@
     "types": ["vite/client", "@types/node", "vitest/globals", "@testing-library/jest-dom"]
   },
   "include": [
+    "src/**/*.d.ts",
     "src/**/*.test.ts",
     "src/**/*.test.tsx",
     "src/**/__tests__/**/*",


### PR DESCRIPTION
## Summary

- Add focused coverage for Hermes-owned critical download paths without testing yt-dlp internals.
- Centralize duplicated progress payload, queue invalidation, queue mapping, query serialization, media extension, and analytics period logic.
- Keep public API behavior compatible while making critical orchestration and state-shaping paths easier to verify.

## Details

- Backend coverage now exercises download start/status/cancel/batch endpoint orchestration plus task state transitions for success, extract failure, missing output files, progress shaping, and batch aggregation.
- Frontend coverage now exercises bulk operations, queue cache invalidation, queue data mapping, queue query keys, and API query parameter serialization.
- Refactors introduce shared helpers for download progress payloads, queue invalidation, queue data mapping, API search params, media constants, and period deltas.

## Verification

- `uv run pytest tests/test_api/test_downloads.py tests/test_tasks/test_download_tasks.py tests/test_services/test_yt_dlp_service.py tests/test_utils.py` - 23 passed
- `pnpm test src/hooks/__tests__/useQueueData.test.ts src/hooks/__tests__/useBulkOperations.test.tsx src/lib/__tests__/queryClient.test.ts src/lib/__tests__/queueData.test.ts src/services/__tests__/apiClient.test.ts` - 38 passed
- `pnpm exec tsc -p tsconfig.test.json --noEmit` - passed
- `git diff --check main..HEAD` - passed
