### PR TITLE
[codex] Fix queue bulk data ownership

### DIFF
--- a/packages/hermes-api/app/tasks/download_tasks.py
+++ b/packages/hermes-api/app/tasks/download_tasks.py
@@ -21,7 +21,6 @@ from app.services.yt_dlp_service import YTDLPService
 from app.tasks.celery_app import celery_app
 from app.utils.download_progress import (
     build_download_progress_payload,
-    build_progress_object,
 )
 from app.utils.media import VIDEO_EXTENSIONS
 
@@ -111,6 +110,44 @@ async def _publish_sse_progress(
     )
 
 
+async def _get_progress_payload_fields(
+    download_id: str,
+    status: str,
+    progress: float = None,
+    downloaded_bytes: int = None,
+    total_bytes: int = None,
+    download_speed: float = None,
+    eta: float = None,
+) -> dict[str, Any] | None:
+    """Resolve progress fields for active SSE payloads."""
+    if progress is not None or downloaded_bytes is not None:
+        return {
+            "progress": progress,
+            "downloaded_bytes": downloaded_bytes,
+            "total_bytes": total_bytes,
+            "download_speed": download_speed,
+            "eta": eta,
+        }
+
+    if status not in ("downloading", "processing"):
+        return None
+
+    async with async_session_maker() as session:
+        download_repo = DownloadRepository(session)
+        download = await download_repo.get_by_id(download_id)
+
+        if not download or download.progress is None:
+            return None
+
+        return {
+            "progress": download.progress,
+            "downloaded_bytes": download.downloaded_bytes,
+            "total_bytes": download.total_bytes,
+            "download_speed": download.download_speed,
+            "eta": download.eta,
+        }
+
+
 async def _update_download_status(
     download_id: str,
     status: str,
@@ -149,39 +186,26 @@ async def _update_download_status(
 
     # Optionally publish SSE (disabled during progress updates for frequency control)
     if publish_sse:
-        # Structure to match DownloadStatus schema with nested progress object
+        payload_extra = dict(kwargs)
+        result = payload_extra.pop("result", None)
+        progress_fields = await _get_progress_payload_fields(
+            download_id=download_id,
+            status=status,
+            progress=progress,
+            downloaded_bytes=downloaded_bytes,
+            total_bytes=total_bytes,
+            download_speed=download_speed,
+            eta=eta,
+        )
+
         progress_data = build_download_progress_payload(
             status=status,
             error_message=error_message,
-            **kwargs,
+            result=result,
+            include_progress=progress_fields is not None,
+            **(progress_fields or {}),
+            **payload_extra,
         )
-
-        # Add nested progress object (matching _publish_sse_progress structure)
-        # Always include progress for active downloads to prevent frontend state loss
-        if progress is not None or downloaded_bytes is not None:
-            progress_data["progress"] = build_progress_object(
-                status=status,
-                progress=progress,
-                downloaded_bytes=downloaded_bytes,
-                total_bytes=total_bytes,
-                download_speed=download_speed,
-                eta=eta,
-            )
-        elif status in ("downloading", "processing"):
-            # For active downloads without new progress data, fetch current progress from DB
-            # to prevent SSE events from wiping out frontend progress state
-            async with async_session_maker() as session:
-                download_repo = DownloadRepository(session)
-                download = await download_repo.get_by_id(download_id)
-                if download and download.progress is not None:
-                    progress_data["progress"] = build_progress_object(
-                        status=status,
-                        progress=download.progress,
-                        downloaded_bytes=download.downloaded_bytes,
-                        total_bytes=download.total_bytes,
-                        download_speed=download.download_speed,
-                        eta=download.eta,
-                    )
 
         # Debug logging to trace SSE events
         logger.info(

--- a/packages/hermes-api/app/utils/download_progress.py
+++ b/packages/hermes-api/app/utils/download_progress.py
@@ -56,7 +56,7 @@ def build_download_progress_payload(
             eta=eta,
         )
 
-    if result:
+    if result is not None:
         payload["result"] = result
 
     return payload

--- a/packages/hermes-api/tests/test_utils.py
+++ b/packages/hermes-api/tests/test_utils.py
@@ -34,6 +34,15 @@ def test_build_download_progress_payload_uses_nested_progress_shape():
     }
 
 
+def test_build_download_progress_payload_preserves_empty_result_object():
+    payload = build_download_progress_payload(
+        status="downloading",
+        result={},
+    )
+
+    assert payload["result"] == {}
+
+
 def test_progress_fields_from_payload_accepts_nested_task_payload():
     fields = progress_fields_from_payload(
         {

--- a/packages/hermes-app/src/components/queue/BulkOperations.tsx
+++ b/packages/hermes-app/src/components/queue/BulkOperations.tsx
@@ -3,13 +3,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Trash2, X, CheckSquare, Square, RefreshCw } from 'lucide-react'
 import { useConfirmation } from '@/hooks/useConfirmation'
 import { ConfirmationDialog } from '@/components/ui/confirmation-dialog'
-
-interface BulkOperationItem {
-  id: string
-  title: string
-  filePath?: string
-  status: string
-}
+import type { BulkOperationItem } from '@/lib/queueData'
 
 interface BulkOperationsProps {
   selectedCount: number

--- a/packages/hermes-app/src/components/queue/QueueList.tsx
+++ b/packages/hermes-app/src/components/queue/QueueList.tsx
@@ -5,34 +5,30 @@ import { EmptyState } from '@/components/ui/empty-state'
 import { ErrorDisplay } from '@/components/ui/error-display'
 import { ConnectionStatus } from '@/components/ui/ConnectionStatus'
 import { FileVideo, Clock, CheckCircle } from 'lucide-react'
-import { useMemo } from 'react'
-import { useFilteredDownloads } from '@/hooks/useFilters'
-import type { components } from '@/types/api.generated'
-import { useQueueData } from '@/hooks/useQueueData'
-
-type DownloadStatus = components["schemas"]["DownloadStatus"]
+import type { DownloadStatus } from '@/lib/queueData'
 
 interface QueueListProps {
   viewMode: 'active' | 'history' | 'all'
-  statusFilter: string
   searchQuery: string
-  // Sorting props
-  sortBy: 'date' | 'size' | 'title' | 'status'
-  sortOrder: 'asc' | 'desc'
+  items: DownloadStatus[]
+  isLoading?: boolean
+  error?: unknown
+  onRetry?: () => void
   // Bulk operations props
   isSelectable?: boolean
   selectedItems?: Set<string>
   onToggleSelect?: (downloadId: string) => void
-  onSelectAll?: (items: DownloadStatus[]) => void
+  onSelectAll?: () => void
   onDeselectAll?: () => void
 }
 
 export function QueueList({
   viewMode,
-  statusFilter,
   searchQuery,
-  sortBy,
-  sortOrder,
+  items,
+  isLoading = false,
+  error,
+  onRetry,
   isSelectable = false,
   selectedItems = new Set(),
   onToggleSelect,
@@ -43,44 +39,6 @@ export function QueueList({
   // SSE for real-time updates (invalidates query cache when updates arrive)
   const { isConnected, isReconnecting, reconnectAttempts } = useQueueUpdatesSSE();
 
-  // Initial data load
-  const { data: queueData, isLoading, error, refetch } = useQueueData({
-    statusFilter,
-    viewMode,
-  })
-
-  // Use the useFilteredDownloads hook for filtering and sorting
-  const sortedItems = useFilteredDownloads(
-    queueData?.items || [],
-    {
-      statusFilter,
-      searchQuery,
-      viewMode,
-      sortBy,
-      sortOrder,
-    }
-  )
-
-  // Apply view mode filtering (the useFilteredDownloads hook doesn't handle this)
-  const filteredItems = useMemo(() => {
-    if (!sortedItems) return []
-
-    let items = sortedItems
-
-    // Filter by view mode
-    if (viewMode === 'active') {
-      items = items.filter(
-        (item: DownloadStatus) =>
-          item.status !== 'completed' ||
-          (item.status === 'completed' && !(item.result as { completed_at?: string })?.completed_at)
-      )
-    } else if (viewMode === 'history') {
-      items = items.filter((item: DownloadStatus) => item.status === 'completed')
-    }
-
-    return items
-  }, [sortedItems, viewMode])
-
   if (isLoading) {
     return <QueueSkeleton />
   }
@@ -89,12 +47,12 @@ export function QueueList({
     return (
       <ErrorDisplay
         message="Failed to load downloads. Please check your connection and try again."
-        onRetry={() => refetch()}
+        onRetry={onRetry}
       />
     )
   }
 
-  if (filteredItems.length === 0) {
+  if (items.length === 0) {
     // Determine empty state based on context
     if (searchQuery) {
       return (
@@ -136,8 +94,8 @@ export function QueueList({
   }
 
   const handleSelectAll = () => {
-    if (onSelectAll && filteredItems.length > 0) {
-      onSelectAll(filteredItems)
+    if (onSelectAll && items.length > 0) {
+      onSelectAll()
     }
   }
 
@@ -148,7 +106,8 @@ export function QueueList({
   }
 
   // Update BulkOperations props with actual data
-  const allSelected = filteredItems.length > 0 && filteredItems.every((item: DownloadStatus) => selectedItems.has(item.downloadId))
+  const selectedVisibleCount = items.filter((item) => selectedItems.has(item.downloadId)).length
+  const allSelected = items.length > 0 && selectedVisibleCount === items.length
 
   return (
     <div className="space-y-3">
@@ -161,11 +120,11 @@ export function QueueList({
       />
 
       {/* Select All Controls */}
-      {isSelectable && filteredItems.length > 0 && (
+      {isSelectable && items.length > 0 && (
         <div className="flex items-center justify-between p-2 bg-muted/50 rounded-md">
           <div className="flex items-center gap-2">
             <span className="text-sm text-muted-foreground">
-              {allSelected ? 'All selected' : `${selectedItems.size} of ${filteredItems.length} selected`}
+              {allSelected ? 'All selected' : `${selectedVisibleCount} of ${items.length} selected`}
             </span>
           </div>
           <div className="flex items-center gap-2">
@@ -179,7 +138,7 @@ export function QueueList({
         </div>
       )}
 
-      {filteredItems.map((download: DownloadStatus) => (
+      {items.map((download: DownloadStatus) => (
         <QueueCard
           key={download.downloadId}
           download={download}

--- a/packages/hermes-app/src/components/queue/QueueTabContent.tsx
+++ b/packages/hermes-app/src/components/queue/QueueTabContent.tsx
@@ -4,9 +4,18 @@ import { QueueStats } from './QueueStats'
 import { BulkOperations } from './BulkOperations'
 import { useBulkOperations } from '@/hooks/useBulkOperations'
 import { useQueueData } from '@/hooks/useQueueData'
-import { toBulkOperationItems } from '@/lib/queueData'
+import {
+  getQueueDisplayStatusFilter,
+  getVisibleQueueItems,
+  toBulkOperationItems,
+  type DownloadStatus,
+} from '@/lib/queueData'
+import { useFilteredDownloads } from '@/hooks/useFilters'
+import { useMemo } from 'react'
 
 import type { FilterState } from '@/hooks/useFilters'
+
+const EMPTY_QUEUE_ITEMS: DownloadStatus[] = []
 
 interface QueueTabContentProps {
   viewMode: 'active' | 'history' | 'all'
@@ -30,13 +39,24 @@ export function QueueTabContent({
   const typedSortOrder = sortOrder as FilterState['sortOrder']
   const bulkOperations = useBulkOperations()
 
-  // Get current queue data for bulk operations
-  // Uses same query key as QueueList so SSE invalidation updates both
-  const { data: queueData } = useQueueData({
+  // Derive the visible queue once so list rendering and bulk actions stay aligned.
+  const { data: queueData, isLoading, error, refetch } = useQueueData({
     statusFilter,
     viewMode,
   })
-  const bulkItems = toBulkOperationItems(queueData?.items)
+  const displayStatusFilter = getQueueDisplayStatusFilter(viewMode, statusFilter)
+  const queueItems = queueData?.items ?? EMPTY_QUEUE_ITEMS
+  const filterState = useMemo<FilterState>(() => ({
+    statusFilter: displayStatusFilter,
+    searchQuery,
+    viewMode,
+    sortBy: typedSortBy,
+    sortOrder: typedSortOrder,
+  }), [displayStatusFilter, searchQuery, viewMode, typedSortBy, typedSortOrder])
+  const sortedItems = useFilteredDownloads(queueItems, filterState)
+  const visibleItems = getVisibleQueueItems(sortedItems, viewMode)
+  const bulkItems = toBulkOperationItems(visibleItems)
+  const selectedBulkItems = bulkOperations.getSelectedItems(bulkItems)
 
   return (
     <div className="space-y-4">
@@ -44,9 +64,9 @@ export function QueueTabContent({
 
       {/* Bulk Operations Toolbar */}
       <BulkOperations
-        selectedCount={bulkOperations.selectedCount}
-        totalCount={queueData?.items?.length || 0}
-        selectedItems={bulkOperations.getSelectedItems(bulkItems)}
+        selectedCount={selectedBulkItems.length}
+        totalCount={visibleItems.length}
+        selectedItems={selectedBulkItems}
         onSelectAll={() => {
           bulkOperations.selectAll(bulkItems)
         }}
@@ -60,14 +80,15 @@ export function QueueTabContent({
         <CardContent className="pt-6">
           <QueueList
             viewMode={viewMode}
-            statusFilter={statusFilter}
             searchQuery={searchQuery}
-            sortBy={typedSortBy}
-            sortOrder={typedSortOrder}
+            items={visibleItems}
+            isLoading={isLoading}
+            error={error}
+            onRetry={() => refetch()}
             isSelectable={true}
             selectedItems={bulkOperations.selectedItems}
             onToggleSelect={bulkOperations.toggleItem}
-            onSelectAll={(items) => bulkOperations.selectAll(toBulkOperationItems(items))}
+            onSelectAll={() => bulkOperations.selectAll(bulkItems)}
             onDeselectAll={bulkOperations.deselectAll}
           />
         </CardContent>

--- a/packages/hermes-app/src/lib/__tests__/queueData.test.ts
+++ b/packages/hermes-app/src/lib/__tests__/queueData.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
+  getQueueDisplayStatusFilter,
   getQueueStatusFilter,
+  getVisibleQueueItems,
   toBulkOperationItem,
   toBulkOperationItems,
   type DownloadStatus,
@@ -10,8 +12,46 @@ describe('queueData helpers', () => {
   it('resolves queue status filters from view state', () => {
     expect(getQueueStatusFilter('active', 'all')).toBeUndefined()
     expect(getQueueStatusFilter('active', 'downloading')).toBe('downloading')
+    expect(getQueueStatusFilter('active', 'completed')).toBeUndefined()
     expect(getQueueStatusFilter('history', 'failed')).toBe('completed')
     expect(getQueueStatusFilter('all', 'failed')).toBeUndefined()
+  })
+
+  it('normalizes stale status filters for visible queue data', () => {
+    expect(getQueueDisplayStatusFilter('active', 'completed')).toBe('all')
+    expect(getQueueDisplayStatusFilter('active', 'failed')).toBe('failed')
+    expect(getQueueDisplayStatusFilter('history', 'failed')).toBe('all')
+    expect(getQueueDisplayStatusFilter('history', 'completed')).toBe('completed')
+    expect(getQueueDisplayStatusFilter('all', 'failed')).toBe('failed')
+  })
+
+  it('filters queue items by visible view mode', () => {
+    const items = [
+      { downloadId: 'queued', status: 'queued' },
+      { downloadId: 'completed', status: 'completed' },
+      {
+        downloadId: 'active-completed',
+        status: 'completed',
+        result: {},
+      },
+      {
+        downloadId: 'history-completed',
+        status: 'completed',
+        result: { completed_at: '2026-01-01T00:00:00Z' },
+      },
+    ] as DownloadStatus[]
+
+    expect(getVisibleQueueItems(items, 'active').map((item) => item.downloadId)).toEqual([
+      'queued',
+      'completed',
+      'active-completed',
+    ])
+    expect(getVisibleQueueItems(items, 'history').map((item) => item.downloadId)).toEqual([
+      'completed',
+      'active-completed',
+      'history-completed',
+    ])
+    expect(getVisibleQueueItems(items, 'all')).toEqual(items)
   })
 
   it('maps download status records into bulk operation items', () => {

--- a/packages/hermes-app/src/lib/queueData.ts
+++ b/packages/hermes-app/src/lib/queueData.ts
@@ -3,6 +3,8 @@ import type { components } from '@/types/api.generated'
 export type DownloadStatus = components["schemas"]["DownloadStatus"]
 export type QueueViewMode = 'active' | 'history' | 'all'
 
+const ACTIVE_STATUS_FILTERS = new Set(['downloading', 'queued', 'processing', 'failed'])
+
 export interface BulkOperationItem {
   id: string
   title: string
@@ -15,7 +17,7 @@ export function getQueueStatusFilter(
   statusFilter: string
 ): string | undefined {
   if (viewMode === 'active') {
-    return statusFilter === 'all' ? undefined : statusFilter
+    return ACTIVE_STATUS_FILTERS.has(statusFilter) ? statusFilter : undefined
   }
 
   if (viewMode === 'history') {
@@ -23,6 +25,40 @@ export function getQueueStatusFilter(
   }
 
   return undefined
+}
+
+export function getQueueDisplayStatusFilter(
+  viewMode: QueueViewMode,
+  statusFilter: string
+): string {
+  if (viewMode === 'active') {
+    return ACTIVE_STATUS_FILTERS.has(statusFilter) ? statusFilter : 'all'
+  }
+
+  if (viewMode === 'history') {
+    return statusFilter === 'completed' ? 'completed' : 'all'
+  }
+
+  return statusFilter
+}
+
+export function getVisibleQueueItems(
+  items: DownloadStatus[],
+  viewMode: QueueViewMode
+): DownloadStatus[] {
+  if (viewMode === 'active') {
+    return items.filter(
+      (item) =>
+        item.status !== 'completed' ||
+        (item.status === 'completed' && !(item.result as { completed_at?: string })?.completed_at)
+    )
+  }
+
+  if (viewMode === 'history') {
+    return items.filter((item) => item.status === 'completed')
+  }
+
+  return items
 }
 
 export function toBulkOperationItem(item: DownloadStatus): BulkOperationItem {


### PR DESCRIPTION
## Summary
- Align queue list rendering and bulk operation data around one visible item derivation
- Normalize stale queue status filters before deriving visible items
- Consolidate download progress SSE payload construction through the shared helper

## Validation
- pnpm --filter hermes-app type-check
- pnpm --filter hermes-app lint
- pnpm --filter hermes-app test -- src/lib/__tests__/queueData.test.ts src/hooks/__tests__/useQueueData.test.ts
- uv run pytest tests/test_utils.py tests/test_tasks/test_download_tasks.py
- uv run ruff check app/tasks/download_tasks.py app/utils/download_progress.py tests/test_utils.py
- uv run black --check app/tasks/download_tasks.py app/utils/download_progress.py tests/test_utils.py
- git diff --check

## Notes
- Installed frontend dependencies locally because this worktree had no node_modules; no lockfile changes were produced.