### PR TITLE
ci: update actions for Node 24

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -54,10 +54,10 @@ jobs:
           pnpm pre-check
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -65,7 +65,7 @@ jobs:
 
       - name: Extract metadata for hermes-app
         id: meta-app
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/hermes-app
           tags: |
@@ -73,7 +73,7 @@ jobs:
             type=sha,prefix=develop-
 
       - name: Build and push hermes-app Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./packages/hermes-app/Dockerfile
@@ -88,7 +88,7 @@ jobs:
 
       - name: Extract metadata for hermes-api
         id: meta-api
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/hermes-api
           tags: |
@@ -96,7 +96,7 @@ jobs:
             type=sha,prefix=develop-
 
       - name: Build and push hermes-api Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./packages/hermes-api
           file: ./packages/hermes-api/Dockerfile

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/publish-release-images.yml
+++ b/.github/workflows/publish-release-images.yml
@@ -83,7 +83,7 @@ jobs:
           fi
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -112,10 +112,10 @@ jobs:
           pnpm pre-check
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -123,7 +123,7 @@ jobs:
 
       - name: Extract metadata for hermes-app
         id: meta-app
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/hermes-app
           tags: |
@@ -133,7 +133,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push hermes-app Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./packages/hermes-app/Dockerfile
@@ -148,7 +148,7 @@ jobs:
 
       - name: Extract metadata for hermes-api
         id: meta-api
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/hermes-api
           tags: |
@@ -158,7 +158,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push hermes-api Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./packages/hermes-api
           file: ./packages/hermes-api/Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -205,10 +205,10 @@ jobs:
           echo "Pushed commit and tags to main"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -216,7 +216,7 @@ jobs:
 
       - name: Extract metadata for hermes-app
         id: meta-app
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/hermes-app
           tags: |
@@ -228,7 +228,7 @@ jobs:
             org.opencontainers.image.revision=${{ steps.release_commit.outputs.sha }}
 
       - name: Build and push hermes-app Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./packages/hermes-app/Dockerfile
@@ -243,7 +243,7 @@ jobs:
 
       - name: Extract metadata for hermes-api
         id: meta-api
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/hermes-api
           tags: |
@@ -255,7 +255,7 @@ jobs:
             org.opencontainers.image.revision=${{ steps.release_commit.outputs.sha }}
 
       - name: Build and push hermes-api Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./packages/hermes-api
           file: ./packages/hermes-api/Dockerfile


### PR DESCRIPTION
## Summary
- update pnpm/action-setup to v6
- update Docker GitHub Actions to Node 24-compatible major versions
- apply the action pin updates across PR checks, develop, release image publishing, and release workflows

## Validation
- git diff --check
- verified no old pnpm/Docker action pins remain
- pnpm pre-check reached Docker build after backend and frontend checks passed; Docker daemon was unavailable at that moment
- docker compose build passed after restarting Colima