### PR TITLE
fix(api): queue batch downloads through celery

### DIFF
--- a/packages/hermes-api/app/api/v1/endpoints/downloads.py
+++ b/packages/hermes-api/app/api/v1/endpoints/downloads.py
@@ -2,7 +2,7 @@
 Download management endpoints.
 """
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.logging import get_logger
@@ -257,7 +257,6 @@ async def cancel_download(
 @router.post("/batch")
 async def start_batch_download(
     batch_request: BatchDownloadRequest,  # Renamed from 'request' to avoid conflicts
-    background_tasks: BackgroundTasks,
     db_session: AsyncSession = Depends(get_database_session),
     principal: AuthPrincipal = Depends(require_api_permission(ApiKeyPermission.WRITE)),
 ) -> BatchDownloadResponse:
@@ -300,12 +299,14 @@ async def start_batch_download(
         logger.info("Created download records", download_count=len(download_ids))
 
         # Queue the batch download task with real download IDs
-        background_tasks.add_task(
-            batch_download_task,
-            download_ids,
-            batch_request.urls,
-            batch_request.format,
-            batch_request.output_directory,
+        batch_download_task.apply_async(
+            kwargs={
+                "download_ids": download_ids,
+                "urls": batch_request.urls,
+                "format_spec": batch_request.format,
+                "output_directory": batch_request.output_directory,
+            },
+            queue="hermes.downloads",
         )
 
         logger.info(

--- a/packages/hermes-api/tests/test_api/test_downloads.py
+++ b/packages/hermes-api/tests/test_api/test_downloads.py
@@ -4,7 +4,7 @@ External work queues and Redis are mocked; these tests cover API-owned request
 handling, persistence, response shaping, and state transitions.
 """
 
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import AsyncClient
@@ -183,9 +183,9 @@ class TestDownloadEndpoints:
     async def test_start_batch_download_creates_records_and_schedules_batch(
         self, client: AsyncClient, db_session: AsyncSession
     ):
-        batch_task = Mock()
-
-        with patch("app.api.v1.endpoints.downloads.batch_download_task", batch_task):
+        with patch(
+            "app.api.v1.endpoints.downloads.batch_download_task.apply_async"
+        ) as apply_async:
             response = await client.post(
                 "/api/v1/download/batch",
                 json={
@@ -215,9 +215,12 @@ class TestDownloadEndpoints:
         ]
         assert [download.status for download in downloads] == ["pending", "pending"]
 
-        batch_task.assert_called_once_with(
-            data["downloads"],
-            ["https://example.test/one", "https://example.test/two"],
-            "best",
-            "/downloads/batch",
+        apply_async.assert_called_once_with(
+            kwargs={
+                "download_ids": data["downloads"],
+                "urls": ["https://example.test/one", "https://example.test/two"],
+                "format_spec": "best",
+                "output_directory": "/downloads/batch",
+            },
+            queue="hermes.downloads",
         )


### PR DESCRIPTION
## Summary
- route batch downloads through Celery with apply_async, matching single-download behavior
- remove FastAPI in-process background execution for batch work
- update endpoint tests to assert broker scheduling on the downloads queue

## Validation
- uv run black app/api/v1/endpoints/downloads.py tests/test_api/test_downloads.py
- uv run ruff check app/api/v1/endpoints/downloads.py tests/test_api/test_downloads.py
- uv run pytest tests/test_api/test_downloads.py tests/test_tasks/test_download_tasks.py tests/test_tasks/test_celery_app.py