### PR TITLE
fix(api): accept camelcase refresh token payloads

### DIFF
--- a/packages/hermes-api/app/api/v1/endpoints/auth.py
+++ b/packages/hermes-api/app/api/v1/endpoints/auth.py
@@ -120,6 +120,12 @@ class TokenResponse(CamelCaseModel):
     token_type: str = "bearer"
 
 
+class RefreshTokenRequest(CamelCaseModel):
+    """Refresh-token request accepting camelCase and snake_case input."""
+
+    refresh_token: str
+
+
 class UserResponse(CamelCaseModel):
     """User information response model with automatic camelCase conversion."""
 
@@ -369,11 +375,12 @@ async def logout(
 
 @router.post("/refresh")
 async def refresh_token(
-    refresh_data: dict, db_session: AsyncSession = Depends(get_database_session)
+    refresh_data: RefreshTokenRequest,
+    db_session: AsyncSession = Depends(get_database_session),
 ) -> TokenResponse:
     """Refresh access token using refresh token."""
     try:
-        refresh_token = refresh_data.get("refresh_token")
+        refresh_token = refresh_data.refresh_token
         if not refresh_token:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,

--- a/packages/hermes-api/tests/test_api/test_auth.py
+++ b/packages/hermes-api/tests/test_api/test_auth.py
@@ -95,7 +95,7 @@ class TestAuthentication:
 
         response = await client.post(
             "/api/v1/auth/refresh",
-            json={"refresh_token": create_refresh_token(token_data)},
+            json={"refreshToken": create_refresh_token(token_data)},
         )
 
         assert response.status_code == 200


### PR DESCRIPTION
## Summary
- replace the raw refresh-token body dict with a camelCase-aware request model
- accept the frontend's refreshToken payload while preserving snake_case input support
- update auth coverage to exercise the browser-style refreshToken body

## Validation
- uv run black app/api/v1/endpoints/auth.py tests/test_api/test_auth.py
- uv run ruff check app/api/v1/endpoints/auth.py tests/test_api/test_auth.py
- uv run pytest tests/test_api/test_auth.py
- pnpm --filter hermes-app test -- --run src/services/__tests__/apiClient.test.ts src/services/__tests__/auth.test.ts